### PR TITLE
Extract Amazon CSV matching logic and add Jest unit tests

### DIFF
--- a/tracker/.gitignore
+++ b/tracker/.gitignore
@@ -12,3 +12,4 @@ logs
 .yarnrc.yml
 
 app/config.ts
+package-lock.json

--- a/tracker/app/transactions/__test__/amazonImportUtils.spec.ts
+++ b/tracker/app/transactions/__test__/amazonImportUtils.spec.ts
@@ -1,0 +1,263 @@
+import { ITransaction } from '../model';
+import {
+  daysDiff,
+  extractNote,
+  matchCsvRow,
+  parseCsv,
+  parseField,
+  parsePayment,
+  parseRow,
+} from '../amazonImportUtils';
+
+function makeTxn(
+  overrides: Partial<ITransaction> & { id: string },
+): ITransaction {
+  return {
+    description: 'AMAZON.COM',
+    original_line: '',
+    date: '2024-01-01',
+    tags: [],
+    amount_cents: 1000,
+    transactions: [],
+    ...overrides,
+  };
+}
+
+// --- parseField ---
+
+describe('parseField', () => {
+  it('parses a plain unquoted field', () => {
+    expect(parseField('hello,world', 0)).toEqual(['hello', 6]);
+  });
+
+  it('parses the last field with no trailing comma', () => {
+    expect(parseField('hello,world', 6)).toEqual(['world', 12]);
+  });
+
+  it('parses a quoted field', () => {
+    expect(parseField('"hello world",next', 0)).toEqual(['hello world', 14]);
+  });
+
+  it('handles escaped double-quotes inside a quoted field', () => {
+    expect(parseField('"say ""hi""",next', 0)).toEqual(['say "hi"', 13]);
+  });
+
+  it('parses an empty unquoted field', () => {
+    expect(parseField(',next', 0)).toEqual(['', 1]);
+  });
+});
+
+// --- parseRow ---
+
+describe('parseRow', () => {
+  it('splits a simple row', () => {
+    expect(parseRow('a,b,c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('handles quoted fields with commas inside', () => {
+    expect(parseRow('"a,b",c')).toEqual(['a,b', 'c']);
+  });
+
+  it('handles a single-field row', () => {
+    expect(parseRow('only')).toEqual(['only']);
+  });
+
+  it('preserves empty fields', () => {
+    expect(parseRow('a,,c')).toEqual(['a', '', 'c']);
+  });
+});
+
+// --- parseCsv ---
+
+describe('parseCsv', () => {
+  it('returns empty array for fewer than 2 lines', () => {
+    expect(parseCsv('')).toEqual([]);
+    expect(parseCsv('header only')).toEqual([]);
+  });
+
+  it('maps rows to header-keyed objects', () => {
+    const result = parseCsv('name,amount\nfoo,42');
+    expect(result).toEqual([{ name: 'foo', amount: '42' }]);
+  });
+
+  it('strips a leading UTF-8 BOM', () => {
+    const result = parseCsv('﻿name,amount\nbar,10');
+    expect(result).toEqual([{ name: 'bar', amount: '10' }]);
+  });
+
+  it('normalizes Windows line endings (CRLF)', () => {
+    const result = parseCsv('name,amount\r\nbaz,99\r\n');
+    expect(result).toEqual([{ name: 'baz', amount: '99' }]);
+  });
+
+  it('trims header whitespace', () => {
+    const result = parseCsv(' name , amount \nfoo,5');
+    expect(result).toEqual([{ name: 'foo', amount: '5' }]);
+  });
+
+  it('handles multiple data rows', () => {
+    const result = parseCsv('a,b\n1,2\n3,4');
+    expect(result).toHaveLength(2);
+    expect(result[1]).toEqual({ a: '3', b: '4' });
+  });
+
+  it('fills missing fields with empty string', () => {
+    const result = parseCsv('a,b,c\n1,2');
+    expect(result[0].c).toBe('');
+  });
+});
+
+// --- parsePayment ---
+
+describe('parsePayment', () => {
+  it('parses a standard card payment entry', () => {
+    const result = parsePayment('Visa: 2024-01-15: $45.99', '', '');
+    expect(result).toEqual({ date: '2024-01-15', amountCents: 4599 });
+  });
+
+  it('returns the first valid entry when multiple are present', () => {
+    const result = parsePayment(
+      'Visa: 2024-01-15: $10.00; Mastercard: 2024-01-20: $5.00',
+      '',
+      '',
+    );
+    expect(result).toEqual({ date: '2024-01-15', amountCents: 1000 });
+  });
+
+  it('parses amounts with comma separators', () => {
+    const result = parsePayment('Visa: 2024-03-01: $1,234.56', '', '');
+    expect(result).toEqual({ date: '2024-03-01', amountCents: 123456 });
+  });
+
+  it('falls back to order date + total for gift-card-only payments', () => {
+    const result = parsePayment('Gift Card: 2024-02-01: $0.00', '2024-02-01', '29.99');
+    expect(result).toEqual({ date: '2024-02-01', amountCents: 2999 });
+  });
+
+  it('returns null when no valid payment and no fallback', () => {
+    expect(parsePayment('', '', '')).toBeNull();
+  });
+
+  it('skips entries with zero amount', () => {
+    const result = parsePayment('Visa: 2024-01-01: $0.00', '2024-01-01', '9.99');
+    expect(result).toEqual({ date: '2024-01-01', amountCents: 999 });
+  });
+
+  it('skips entries with an invalid date format', () => {
+    const result = parsePayment('Visa: Jan 15: $10.00', '2024-01-15', '10.00');
+    expect(result).toEqual({ date: '2024-01-15', amountCents: 1000 });
+  });
+
+  it('rounds fractional cents correctly', () => {
+    const result = parsePayment('Visa: 2024-01-01: $9.999', '', '');
+    expect(result).toEqual({ date: '2024-01-01', amountCents: 1000 });
+  });
+});
+
+// --- extractNote ---
+
+describe('extractNote', () => {
+  it('returns the first item when there is only one', () => {
+    expect(extractNote('Widget A')).toBe('Widget A');
+  });
+
+  it('returns only the first item from a semicolon-separated list', () => {
+    expect(extractNote('Widget A; Widget B; Widget C')).toBe('Widget A');
+  });
+
+  it('trims whitespace around the first item', () => {
+    expect(extractNote('  Widget A  ; Widget B')).toBe('Widget A');
+  });
+
+  it('returns a string of exactly 80 chars unchanged', () => {
+    const s = 'a'.repeat(80);
+    expect(extractNote(s)).toBe(s);
+  });
+
+  it('truncates strings longer than 80 chars with ellipsis', () => {
+    const s = 'a'.repeat(81);
+    const result = extractNote(s);
+    expect(result).toHaveLength(80);
+    expect(result.endsWith('...')).toBe(true);
+  });
+});
+
+// --- daysDiff ---
+
+describe('daysDiff', () => {
+  it('returns 0 for the same date', () => {
+    expect(daysDiff('2024-01-01', '2024-01-01')).toBe(0);
+  });
+
+  it('returns 1 for consecutive days', () => {
+    expect(daysDiff('2024-01-01', '2024-01-02')).toBe(1);
+  });
+
+  it('returns a negative value when toDate is before fromDate', () => {
+    expect(daysDiff('2024-01-10', '2024-01-01')).toBe(-9);
+  });
+
+  it('handles month boundaries', () => {
+    expect(daysDiff('2024-01-31', '2024-02-01')).toBe(1);
+  });
+});
+
+// --- matchCsvRow ---
+
+describe('matchCsvRow', () => {
+  const csvRow = { items: 'Widget', paymentDate: '2024-01-01', amountCents: 5000 };
+
+  it('matches a single transaction on the same day', () => {
+    const txn = makeTxn({ id: 't1', date: '2024-01-01', amount_cents: 5000 });
+    expect(matchCsvRow(csvRow, [txn])).toEqual([txn]);
+  });
+
+  it('matches a single transaction 7 days after payment date', () => {
+    const txn = makeTxn({ id: 't1', date: '2024-01-08', amount_cents: 5000 });
+    expect(matchCsvRow(csvRow, [txn])).toEqual([txn]);
+  });
+
+  it('does not match a transaction 8 days after payment date', () => {
+    const txn = makeTxn({ id: 't1', date: '2024-01-09', amount_cents: 5000 });
+    expect(matchCsvRow(csvRow, [txn])).toBeNull();
+  });
+
+  it('does not match a transaction before the payment date', () => {
+    const txn = makeTxn({ id: 't1', date: '2023-12-31', amount_cents: 5000 });
+    expect(matchCsvRow(csvRow, [txn])).toBeNull();
+  });
+
+  it('matches within 1-cent tolerance', () => {
+    const txn = makeTxn({ id: 't1', date: '2024-01-03', amount_cents: 5001 });
+    expect(matchCsvRow(csvRow, [txn])).toEqual([txn]);
+  });
+
+  it('does not match when amount differs by more than 1 cent', () => {
+    const txn = makeTxn({ id: 't1', date: '2024-01-03', amount_cents: 5002 });
+    expect(matchCsvRow(csvRow, [txn])).toBeNull();
+  });
+
+  it('matches a split shipment: two transactions summing to CSV amount within 14 days', () => {
+    const t1 = makeTxn({ id: 't1', date: '2024-01-08', amount_cents: 3000 });
+    const t2 = makeTxn({ id: 't2', date: '2024-01-14', amount_cents: 2000 });
+    expect(matchCsvRow(csvRow, [t1, t2])).toEqual([t1, t2]);
+  });
+
+  it('does not split-match when one transaction is 15 days out', () => {
+    const t1 = makeTxn({ id: 't1', date: '2024-01-08', amount_cents: 3000 });
+    const t2 = makeTxn({ id: 't2', date: '2024-01-16', amount_cents: 2000 });
+    expect(matchCsvRow(csvRow, [t1, t2])).toBeNull();
+  });
+
+  it('prefers single match over split when both would work', () => {
+    const exact = makeTxn({ id: 'exact', date: '2024-01-02', amount_cents: 5000 });
+    const t1 = makeTxn({ id: 't1', date: '2024-01-05', amount_cents: 3000 });
+    const t2 = makeTxn({ id: 't2', date: '2024-01-10', amount_cents: 2000 });
+    const result = matchCsvRow(csvRow, [exact, t1, t2]);
+    expect(result).toEqual([exact]);
+  });
+
+  it('returns null when no transactions are provided', () => {
+    expect(matchCsvRow(csvRow, [])).toBeNull();
+  });
+});

--- a/tracker/app/transactions/amazonImportUtils.ts
+++ b/tracker/app/transactions/amazonImportUtils.ts
@@ -1,0 +1,131 @@
+import { ITransaction } from './model';
+
+export interface ICsvRow {
+  items: string;
+  paymentDate: string;
+  amountCents: number;
+}
+
+export function parseField(row: string, start: number): [string, number] {
+  if (row[start] === '"') {
+    let field = '';
+    let i = start + 1;
+    while (i < row.length) {
+      if (row[i] === '"' && row[i + 1] === '"') {
+        field += '"';
+        i += 2;
+      } else if (row[i] === '"') {
+        return [field, i + 2]; // skip closing quote + comma
+      } else {
+        field += row[i++];
+      }
+    }
+    return [field, i];
+  }
+  const end = row.indexOf(',', start);
+  if (end === -1) {return [row.slice(start), row.length + 1];}
+  return [row.slice(start, end), end + 1];
+}
+
+export function parseRow(row: string): string[] {
+  const fields: string[] = [];
+  let pos = 0;
+  while (pos <= row.length) {
+    const [field, next] = parseField(row, pos);
+    fields.push(field);
+    if (next > row.length) {break;}
+    pos = next;
+  }
+  return fields;
+}
+
+export function parseCsv(text: string): Record<string, string>[] {
+  // Strip BOM and normalize line endings
+  const lines = text
+    .replace(/^﻿/, '')
+    .split('\n')
+    .map(l => l.replace(/\r$/, ''))
+    .filter(Boolean);
+  if (lines.length < 2) {return [];}
+  const headers = parseRow(lines[0]).map(h => h.trim());
+  return lines.slice(1).map(line => {
+    const values = parseRow(line);
+    const obj: Record<string, string> = {};
+    headers.forEach((h, i) => {
+      obj[h] = values[i] ?? '';
+    });
+    return obj;
+  });
+}
+
+// Parses "Card Name: YYYY-MM-DD: $amount; ..." format.
+// Falls back to order date + total for gift-card-only payments.
+export function parsePayment(
+  paymentsStr: string,
+  orderDate: string,
+  totalStr: string,
+): { date: string; amountCents: number } | null {
+  for (const entry of paymentsStr
+    .split(';')
+    .map(e => e.trim())
+    .filter(Boolean)) {
+    const parts = entry.split(':').map(p => p.trim());
+    if (parts.length >= 3 && /^\d{4}-\d{2}-\d{2}$/.test(parts[1])) {
+      const amount = parseFloat(parts[2].replace(/,/g, '').replace('$', ''));
+      if (!isNaN(amount) && amount > 0) {
+        return { date: parts[1], amountCents: Math.round(amount * 100) };
+      }
+    }
+  }
+  // Gift card fallback: use order date + total
+  const total = parseFloat(totalStr.replace(/,/g, ''));
+  if (!isNaN(total) && total > 0 && orderDate) {
+    return { date: orderDate, amountCents: Math.round(total * 100) };
+  }
+  return null;
+}
+
+export function extractNote(items: string): string {
+  const first = items.split(';')[0].trim();
+  return first.length > 80 ? first.slice(0, 77) + '...' : first;
+}
+
+export function daysDiff(fromDate: string, toDate: string): number {
+  return (
+    (new Date(toDate).getTime() - new Date(fromDate).getTime()) / 86400000
+  );
+}
+
+// Charge date is 0-7 days after CSV payment/order date (items ship after order).
+// For split shipments, try pairs of transactions summing to the CSV amount within 14 days.
+export function matchCsvRow(
+  csvRow: ICsvRow,
+  txns: ITransaction[],
+): ITransaction[] | null {
+  const TOL = 1;
+  const near = txns.filter(t => {
+    const d = daysDiff(csvRow.paymentDate, t.date);
+    return d >= 0 && d <= 7;
+  });
+  const single = near.find(
+    t => Math.abs(t.amount_cents - csvRow.amountCents) <= TOL,
+  );
+  if (single) {return [single];}
+
+  const wide = txns.filter(t => {
+    const d = daysDiff(csvRow.paymentDate, t.date);
+    return d >= 0 && d <= 14;
+  });
+  for (let i = 0; i < wide.length; i++) {
+    for (let j = i + 1; j < wide.length; j++) {
+      if (
+        Math.abs(
+          wide[i].amount_cents + wide[j].amount_cents - csvRow.amountCents,
+        ) <= TOL
+      ) {
+        return [wide[i], wide[j]];
+      }
+    }
+  }
+  return null;
+}

--- a/tracker/app/transactions/components/AmazonImportDialog.tsx
+++ b/tracker/app/transactions/components/AmazonImportDialog.tsx
@@ -9,14 +9,16 @@ import { Theme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
 import * as React from 'react';
 import { ITransaction } from '../model';
+import {
+  ICsvRow,
+  daysDiff,
+  extractNote,
+  matchCsvRow,
+  parseCsv,
+  parsePayment,
+} from '../amazonImportUtils';
 
 // --- Types ---
-
-interface ICsvRow {
-  items: string;
-  paymentDate: string;
-  amountCents: number;
-}
 
 interface IMatchResult {
   csvRow: ICsvRow;
@@ -24,132 +26,6 @@ interface IMatchResult {
   isSplit: boolean;
   proposedNote: string;
   checked: boolean;
-}
-
-// --- CSV parsing ---
-
-function parseField(row: string, start: number): [string, number] {
-  if (row[start] === '"') {
-    let field = '';
-    let i = start + 1;
-    while (i < row.length) {
-      if (row[i] === '"' && row[i + 1] === '"') {
-        field += '"';
-        i += 2;
-      } else if (row[i] === '"') {
-        return [field, i + 2]; // skip closing quote + comma
-      } else {
-        field += row[i++];
-      }
-    }
-    return [field, i];
-  }
-  const end = row.indexOf(',', start);
-  if (end === -1) {return [row.slice(start), row.length + 1];}
-  return [row.slice(start, end), end + 1];
-}
-
-function parseRow(row: string): string[] {
-  const fields: string[] = [];
-  let pos = 0;
-  while (pos <= row.length) {
-    const [field, next] = parseField(row, pos);
-    fields.push(field);
-    if (next > row.length) {break;}
-    pos = next;
-  }
-  return fields;
-}
-
-function parseCsv(text: string): Record<string, string>[] {
-  // Strip BOM and normalize line endings
-  const lines = text
-    .replace(/^\uFEFF/, '')
-    .split('\n')
-    .map(l => l.replace(/\r$/, ''))
-    .filter(Boolean);
-  if (lines.length < 2) {return [];}
-  const headers = parseRow(lines[0]).map(h => h.trim());
-  return lines.slice(1).map(line => {
-    const values = parseRow(line);
-    const obj: Record<string, string> = {};
-    headers.forEach((h, i) => {
-      obj[h] = values[i] ?? '';
-    });
-    return obj;
-  });
-}
-
-// Parses "Card Name: YYYY-MM-DD: $amount; ..." format.
-// Falls back to order date + total for gift-card-only payments.
-function parsePayment(
-  paymentsStr: string,
-  orderDate: string,
-  totalStr: string,
-): { date: string; amountCents: number } | null {
-  for (const entry of paymentsStr
-    .split(';')
-    .map(e => e.trim())
-    .filter(Boolean)) {
-    const parts = entry.split(':').map(p => p.trim());
-    if (parts.length >= 3 && /^\d{4}-\d{2}-\d{2}$/.test(parts[1])) {
-      const amount = parseFloat(parts[2].replace(/,/g, '').replace('$', ''));
-      if (!isNaN(amount) && amount > 0) {
-        return { date: parts[1], amountCents: Math.round(amount * 100) };
-      }
-    }
-  }
-  // Gift card fallback: use order date + total
-  const total = parseFloat(totalStr.replace(/,/g, ''));
-  if (!isNaN(total) && total > 0 && orderDate) {
-    return { date: orderDate, amountCents: Math.round(total * 100) };
-  }
-  return null;
-}
-
-function extractNote(items: string): string {
-  const first = items.split(';')[0].trim();
-  return first.length > 80 ? first.slice(0, 77) + '...' : first;
-}
-
-function daysDiff(fromDate: string, toDate: string): number {
-  return (
-    (new Date(toDate).getTime() - new Date(fromDate).getTime()) / 86400000
-  );
-}
-
-// Charge date is 0-7 days after CSV payment/order date (items ship after order).
-// For split shipments, try pairs of transactions summing to the CSV amount within 14 days.
-function matchCsvRow(
-  csvRow: ICsvRow,
-  txns: ITransaction[],
-): ITransaction[] | null {
-  const TOL = 1;
-  const near = txns.filter(t => {
-    const d = daysDiff(csvRow.paymentDate, t.date);
-    return d >= 0 && d <= 7;
-  });
-  const single = near.find(
-    t => Math.abs(t.amount_cents - csvRow.amountCents) <= TOL,
-  );
-  if (single) {return [single];}
-
-  const wide = txns.filter(t => {
-    const d = daysDiff(csvRow.paymentDate, t.date);
-    return d >= 0 && d <= 14;
-  });
-  for (let i = 0; i < wide.length; i++) {
-    for (let j = i + 1; j < wide.length; j++) {
-      if (
-        Math.abs(
-          wide[i].amount_cents + wide[j].amount_cents - csvRow.amountCents,
-        ) <= TOL
-      ) {
-        return [wide[i], wide[j]];
-      }
-    }
-  }
-  return null;
 }
 
 // --- Styles ---


### PR DESCRIPTION
Moves pure functions (parseField, parseRow, parseCsv, parsePayment,
extractNote, daysDiff, matchCsvRow) from AmazonImportDialog into
amazonImportUtils.ts so they can be tested independently. Adds 43
unit tests covering CSV parsing edge cases, payment parsing, note
truncation, and the single/split-shipment matching algorithm.

https://claude.ai/code/session_01DWthFdMWeKBJFQLFR2wHMT