### PR TITLE
Fix Vercel build errors and add GitHub Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  push:
+    paths:
+      - 'tracker/**'
+  pull_request:
+    paths:
+      - 'tracker/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tracker
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: yarn
+          cache-dependency-path: tracker/yarn.lock
+
+      - run: corepack enable
+
+      - run: yarn install --immutable
+
+      - run: yarn test

--- a/tracker/app/transactions/__test__/amazonImportUtils.spec.ts
+++ b/tracker/app/transactions/__test__/amazonImportUtils.spec.ts
@@ -81,7 +81,7 @@ describe('parseCsv', () => {
   });
 
   it('strips a leading UTF-8 BOM', () => {
-    const result = parseCsv('﻿name,amount\nbar,10');
+    const result = parseCsv('\uFEFFname,amount\nbar,10');
     expect(result).toEqual([{ name: 'bar', amount: '10' }]);
   });
 

--- a/tracker/app/transactions/amazonImportUtils.ts
+++ b/tracker/app/transactions/amazonImportUtils.ts
@@ -42,7 +42,7 @@ export function parseRow(row: string): string[] {
 export function parseCsv(text: string): Record<string, string>[] {
   // Strip BOM and normalize line endings
   const lines = text
-    .replace(/^﻿/, '')
+    .replace(/^\uFEFF/, '')
     .split('\n')
     .map(l => l.replace(/\r$/, ''))
     .filter(Boolean);

--- a/tracker/app/transactions/components/AmazonImportDialog.tsx
+++ b/tracker/app/transactions/components/AmazonImportDialog.tsx
@@ -11,7 +11,6 @@ import * as React from 'react';
 import { ITransaction } from '../model';
 import {
   ICsvRow,
-  daysDiff,
   extractNote,
   matchCsvRow,
   parseCsv,


### PR DESCRIPTION
Follow-up fixes after the Amazon CSV matching PR:

- Remove unused `daysDiff` import from `AmazonImportDialog` (TS6133 error)
- Replace literal U+FEFF BOM byte with `﻿` escape in `amazonImportUtils.ts` and its test (ESLint `no-irregular-whitespace` error)
- Add `.github/workflows/test.yml` to run Jest on push/PR when `tracker/` files change

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWthFdMWeKBJFQLFR2wHMT)_