### PR TITLE
Fix GitHub Actions yarn cache detection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: yarn
-          cache-dependency-path: tracker/yarn.lock
+
+      - name: Get yarn cache directory
+        id: yarn-cache-dir
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: yarn-${{ hashFiles('tracker/yarn.lock') }}
 
       - run: yarn install --immutable
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - run: corepack enable
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: yarn
           cache-dependency-path: tracker/yarn.lock
-
-      - run: corepack enable
 
       - run: yarn install --immutable
 


### PR DESCRIPTION
The workflow on main (from PR #96) was broken — `setup-node`'s `cache: yarn` option invokes `/usr/local/bin/yarn` internally, bypassing corepack entirely. This fixes it by querying the cache folder from yarn 4 directly and using `actions/cache` manually.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWthFdMWeKBJFQLFR2wHMT)_