### PR TITLE
Commit .yarnrc.yml to fix CI node-modules linker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: yarn
-          cache-dependency-path: tracker/yarn.lock
+
+      - name: Get yarn cache directory
+        id: yarn-cache-dir
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: yarn-${{ hashFiles('tracker/yarn.lock') }}
 
       - run: yarn install --immutable
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - run: corepack enable
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: yarn
           cache-dependency-path: tracker/yarn.lock
-
-      - run: corepack enable
 
       - run: yarn install --immutable
 

--- a/tracker/.gitignore
+++ b/tracker/.gitignore
@@ -9,7 +9,6 @@ dist/
 logs
 *.log
 .yarn/
-.yarnrc.yml
 
 app/config.ts
 package-lock.json

--- a/tracker/.yarnrc.yml
+++ b/tracker/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
The local Pi had `.yarnrc.yml` gitignored, so CI got a fresh yarn 4 install defaulting to PnP mode — which breaks ts-jest peer dependency resolution. Commits `.yarnrc.yml` with `nodeLinker: node-modules` and removes it from `.gitignore`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWthFdMWeKBJFQLFR2wHMT)_