### PR TITLE
fetch-server: fix daily summary bug, log skip reasons, show in UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This file provides guidance to Claude Code when working with this repository.
 
+## Development Workflow
+
+- Always make changes on a feature branch, never directly on `main`.
+- Push the branch when done, but **do not merge to `main`** — wait for the user to review and approve the PR.
+- If a PR doesn't exist yet for the branch, create one so the user can review it (unless they explicitly say otherwise).
+
 ## Repository Structure
 
 This is a personal finance tracker with two independent parts that share Dropbox as a data layer.

--- a/fetch-server/server.py
+++ b/fetch-server/server.py
@@ -24,6 +24,9 @@ _config = cfg.load()
 _conn = db.get_conn(_config['db_path'])
 db.init_db(_config['db_path'])
 
+# Last daily summary attempt: {'sent_at', 'subject', 'body'} or {'skipped_at', 'reason'}
+_last_summary: dict | None = None
+
 templates = Jinja2Templates(directory='templates')
 
 
@@ -52,13 +55,22 @@ def _reschedule(interval_minutes: int):
 
 
 def _send_daily_summary():
-    cfg = _config
-    if not cfg.get('summary_to') or not cfg.get('smtp_user'):
+    global _last_summary
+    conf = _config
+
+    def _skip(reason: str):
+        global _last_summary
+        print(f'Daily summary skipped: {reason}')
+        _last_summary = {'skipped_at': datetime.now(timezone.utc).isoformat(), 'reason': reason}
+
+    if not conf.get('summary_to'):
+        _skip('summary_to not configured')
         return
 
     since = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
     runs = db.get_runs_since(_conn, since)
     if not runs:
+        _skip('no successful runs with transactions in the past 24 hours')
         return
 
     transactions = []
@@ -68,6 +80,7 @@ def _send_daily_summary():
 
     count = len(transactions)
     if count == 0:
+        _skip('runs found but added_transactions lists were all empty')
         return
 
     lines = [f'{count} new transaction{"s" if count != 1 else ""} in the past 24 hours:\n']
@@ -77,8 +90,13 @@ def _send_daily_summary():
 
     body = '\n'.join(lines)
     subject = f'Spent: {count} new transaction{"s" if count != 1 else ""}'
-    pipeline.send_email(cfg, cfg['summary_to'], subject, body)
-    print(f'Daily summary sent: {count} transaction(s)')
+    pipeline.send_email(conf, conf['summary_to'], subject, body)
+    print(f'Daily summary sent to {conf["summary_to"]}: {count} transaction(s)')
+    _last_summary = {
+        'sent_at': datetime.now(timezone.utc).isoformat(),
+        'subject': subject,
+        'body': body,
+    }
 
 
 @asynccontextmanager
@@ -137,6 +155,7 @@ async def index(request: Request):
         'next_run': next_run,
         'running': _is_running(),
         'git': _git,
+        'last_summary': _last_summary,
     })
 
 

--- a/fetch-server/templates/index.html
+++ b/fetch-server/templates/index.html
@@ -55,6 +55,18 @@
     </form>
   </div>
 
+  <h2>Last Email Summary</h2>
+  {% if last_summary %}
+    {% if last_summary.get('sent_at') %}
+    <p class="meta">Sent at {{ last_summary.sent_at[:19].replace('T', ' ') }} UTC &mdash; <strong>{{ last_summary.subject }}</strong></p>
+    <pre>{{ last_summary.body }}</pre>
+    {% else %}
+    <p class="meta">Skipped at {{ last_summary.skipped_at[:19].replace('T', ' ') }} UTC &mdash; {{ last_summary.reason }}</p>
+    {% endif %}
+  {% else %}
+  <p style="color:#999;font-style:italic">No summary attempted since server start.</p>
+  {% endif %}
+
   <h2>Recent Runs</h2>
   {% if runs %}
   <table>


### PR DESCRIPTION
## Summary

- **Bug fix:** `_send_daily_summary()` was guarding on `smtp_user` config key, which is never actually used (email is sent via Gmail API). Since `smtp_user` has no default and likely isn't in `config.json`, summaries silently never sent. Now only `summary_to` is required.
- **Logging:** Each skip path now prints a reason to stdout (visible in `journalctl -u fetch-server`), and a success print includes the recipient address.
- **UI:** The index page now shows a "Last Email Summary" section — either the subject + body of the last sent summary, the skip reason with timestamp, or a note that no summary has been attempted since server start. State is held in memory and resets on restart.

## Test plan

- [ ] Verify `journalctl -u fetch-server` shows "Daily summary skipped: ..." or "Daily summary sent to ..." after the scheduled hour passes
- [ ] Check the fetch-server index page shows the "Last Email Summary" section correctly after a summary attempt
- [ ] Confirm a summary email is now actually received (previously broken by the `smtp_user` guard)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqYkfpkSi2aTZabQX4MDHg)_