### PR TITLE
Claude API key + CI workflow fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: yarn
-          cache-dependency-path: tracker/yarn.lock
+
+      - name: Get yarn cache directory
+        id: yarn-cache-dir
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: yarn-${{ hashFiles('tracker/yarn.lock') }}
 
       - run: yarn install --immutable
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - run: corepack enable
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: yarn
           cache-dependency-path: tracker/yarn.lock
-
-      - run: corepack enable
 
       - run: yarn install --immutable
 

--- a/tracker/.gitignore
+++ b/tracker/.gitignore
@@ -9,7 +9,6 @@ dist/
 logs
 *.log
 .yarn/
-.yarnrc.yml
 
 app/config.ts
 package-lock.json

--- a/tracker/.yarnrc.yml
+++ b/tracker/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/tracker/app/main/components/Editor.tsx
+++ b/tracker/app/main/components/Editor.tsx
@@ -11,7 +11,8 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import * as Transactions from '../../transactions';
-import { CloudState, IAppState } from '../model';
+import { CloudState, IAppState, ISettings } from '../model';
+import { saveSettingsToDropbox, updateSetting } from '../actions';
 import ClassifyDialog from './ClassifyDialog';
 import EditorMenuBar from './EditorMenuBar';
 
@@ -79,10 +80,12 @@ interface IEditorOwnProps {}
 interface IEditorAppStateProps {
   transactions: Transactions.ITransaction[];
   cloudState: CloudState;
+  anthropicApiKey?: string;
 }
 interface IEditorDispatchProps {
   updateTransactions: (transactions: Transactions.ITransaction[]) => void;
   saveTransactions: () => void;
+  onSaveApiKey: (key: string | undefined) => void;
 }
 type IEditorProps = IEditorOwnProps &
   IEditorAppStateProps &
@@ -249,6 +252,8 @@ class EditorInner extends React.Component<IEditorInnerProps, IEditorState> {
               allTransactions={this.props.transactions}
               onClose={() => this.setState({ isAmazonImportOpen: false })}
               onSaveChanges={this.props.updateTransactions}
+              anthropicApiKey={this.props.anthropicApiKey}
+              onSaveApiKey={this.props.onSaveApiKey}
             />
           ) : undefined}
         </div>
@@ -510,6 +515,7 @@ function EditorWrapper(props: IEditorProps) {
 const mapStateToProps = (state: IAppState): IEditorAppStateProps => ({
   transactions: state.transactions.transactions,
   cloudState: state.transactions.cloudState,
+  anthropicApiKey: state.settings.settings.anthropicApiKey,
 });
 const mapDispatchToProps = (
   dispatch: ThunkDispatch<IAppState, null, any>
@@ -519,6 +525,10 @@ const mapDispatchToProps = (
   },
   saveTransactions: () => {
     dispatch(Transactions.TransactionsActions.saveTransactionsToDropbox());
+  },
+  onSaveApiKey: (key: string | undefined) => {
+    dispatch(updateSetting('anthropicApiKey', key as ISettings[keyof ISettings]));
+    dispatch(saveSettingsToDropbox());
   },
 });
 

--- a/tracker/app/main/model.ts
+++ b/tracker/app/main/model.ts
@@ -83,6 +83,7 @@ export interface ISettings {
   spendTargets: ISpendTarget[];
   /** Category definitions: name → { emoji, tags }. Populated from defaults if absent. */
   categories?: Record<string, ICategoryDefinition>;
+  anthropicApiKey?: string;
 }
 
 export interface ISettingsState {

--- a/tracker/app/transactions/components/AmazonImportDialog.tsx
+++ b/tracker/app/transactions/components/AmazonImportDialog.tsx
@@ -1,9 +1,11 @@
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
+import CircularProgress from '@mui/material/CircularProgress';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { Theme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
@@ -27,6 +29,38 @@ interface IMatchResult {
   checked: boolean;
 }
 
+// --- Claude API ---
+
+async function shortenDescription(items: string, apiKey: string): Promise<string> {
+  const first = items.split(';')[0].trim();
+  try {
+    const resp = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+        'anthropic-dangerous-direct-browser-access': 'true',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 20,
+        messages: [
+          {
+            role: 'user',
+            content: `Shorten this Amazon product title to 4-6 words keeping brand and product type. Reply with only the shortened title.\n\n${first}`,
+          },
+        ],
+      }),
+    });
+    if (!resp.ok) {return extractNote(items);}
+    const data = await resp.json();
+    return data.content?.[0]?.text?.trim() || extractNote(items);
+  } catch {
+    return extractNote(items);
+  }
+}
+
 // --- Styles ---
 
 const useStyles = makeStyles()((_theme: Theme) => ({
@@ -38,6 +72,21 @@ const useStyles = makeStyles()((_theme: Theme) => ({
     gap: '16px',
     padding: '32px',
     textAlign: 'center',
+  },
+  apiKeySection: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '8px',
+    width: '100%',
+    maxWidth: '380px',
+    paddingTop: '16px',
+    borderTop: '1px solid #eee',
+  },
+  apiKeyRow: {
+    display: 'flex',
+    gap: '8px',
+    alignItems: 'center',
   },
   matchList: {
     borderTop: '1px solid lightgrey',
@@ -93,6 +142,8 @@ interface IAmazonImportDialogProps {
   allTransactions: ITransaction[];
   onClose: () => void;
   onSaveChanges: (updatedTransactions: ITransaction[]) => void;
+  anthropicApiKey?: string;
+  onSaveApiKey: (key: string | undefined) => void;
 }
 
 interface IAmazonImportDialogState {
@@ -100,6 +151,9 @@ interface IAmazonImportDialogState {
   matches: IMatchResult[];
   unmatchedCount: number;
   alreadyNotedCount: number;
+  isLoading: boolean;
+  isEditingApiKey: boolean;
+  apiKeyInput: string;
 }
 
 interface IAmazonImportDialogInnerProps extends IAmazonImportDialogProps {
@@ -119,6 +173,9 @@ class AmazonImportDialogInner extends React.Component<
       matches: [],
       unmatchedCount: 0,
       alreadyNotedCount: 0,
+      isLoading: false,
+      isEditingApiKey: false,
+      apiKeyInput: '',
     };
   }
 
@@ -172,6 +229,17 @@ class AmazonImportDialogInner extends React.Component<
 
   private renderUpload() {
     const { classes } = this.props;
+    const { isLoading } = this.state;
+
+    if (isLoading) {
+      return (
+        <div className={classes.uploadArea}>
+          <CircularProgress size={32} />
+          <Typography color="textSecondary">Shortening descriptions with Claude…</Typography>
+        </div>
+      );
+    }
+
     return (
       <div className={classes.uploadArea}>
         <Typography>
@@ -191,6 +259,67 @@ class AmazonImportDialogInner extends React.Component<
         >
           Choose CSV file
         </Button>
+        {this.renderApiKeySection()}
+      </div>
+    );
+  }
+
+  private renderApiKeySection() {
+    const { classes, anthropicApiKey } = this.props;
+    const { isEditingApiKey, apiKeyInput } = this.state;
+    const hasKey = !!anthropicApiKey;
+
+    if (isEditingApiKey) {
+      return (
+        <div className={classes.apiKeySection}>
+          <TextField
+            label="Anthropic API key"
+            value={apiKeyInput}
+            onChange={e => this.setState({ apiKeyInput: e.target.value })}
+            size="small"
+            fullWidth
+            type="password"
+            autoFocus
+          />
+          <div className={classes.apiKeyRow}>
+            <Button
+              size="small"
+              onClick={this.handleSaveApiKey}
+              disabled={!apiKeyInput.trim()}
+            >
+              Save
+            </Button>
+            <Button
+              size="small"
+              onClick={() => this.setState({ isEditingApiKey: false, apiKeyInput: '' })}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className={classes.apiKeySection}>
+        <Typography variant="caption" color="textSecondary">
+          {hasKey
+            ? 'Anthropic API key set — descriptions will be shortened by Claude'
+            : 'No Anthropic API key — descriptions will be truncated'}
+        </Typography>
+        <div className={classes.apiKeyRow}>
+          <Button
+            size="small"
+            onClick={() => this.setState({ isEditingApiKey: true, apiKeyInput: '' })}
+          >
+            {hasKey ? 'Edit key' : 'Set key'}
+          </Button>
+          {hasKey && (
+            <Button size="small" onClick={this.handleClearApiKey}>
+              Clear
+            </Button>
+          )}
+        </div>
       </div>
     );
   }
@@ -246,12 +375,17 @@ class AmazonImportDialogInner extends React.Component<
     const reader = new FileReader();
     reader.onload = event => {
       const text = event.target?.result as string;
-      if (text) {this.parseAndMatch(text);}
+      if (text) {
+        if (this.props.anthropicApiKey) {
+          this.setState({ isLoading: true });
+        }
+        this.parseAndMatch(text);
+      }
     };
     reader.readAsText(file);
   };
 
-  private parseAndMatch(csvText: string) {
+  private async parseAndMatch(csvText: string) {
     const rows = parseCsv(csvText);
     // Amazon transactions only, skip Prime membership fee rows
     const amazonTxns = this.props.allTransactions.filter(
@@ -265,7 +399,7 @@ class AmazonImportDialogInner extends React.Component<
 
     for (const row of rows) {
       const items = row['items']?.trim() ?? '';
-      if (!items) {continue;} // skip rows with no item description
+      if (!items) {continue;}
 
       const payment = parsePayment(
         row['payments'] ?? '',
@@ -304,13 +438,32 @@ class AmazonImportDialogInner extends React.Component<
       a.csvRow.paymentDate.localeCompare(b.csvRow.paymentDate),
     );
 
-    this.setState({ step: 'review', matches, unmatchedCount, alreadyNotedCount });
+    if (this.props.anthropicApiKey) {
+      const shortened = await Promise.all(
+        matches.map(m => shortenDescription(m.csvRow.items, this.props.anthropicApiKey!)),
+      );
+      shortened.forEach((note, i) => {matches[i].proposedNote = note;});
+    }
+
+    this.setState({ step: 'review', matches, unmatchedCount, alreadyNotedCount, isLoading: false });
   }
 
   private handleToggleMatch = (idx: number) => {
     const matches = [...this.state.matches];
     matches[idx] = { ...matches[idx], checked: !matches[idx].checked };
     this.setState({ matches });
+  };
+
+  private handleSaveApiKey = () => {
+    const key = this.state.apiKeyInput.trim();
+    if (key) {
+      this.props.onSaveApiKey(key);
+      this.setState({ isEditingApiKey: false, apiKeyInput: '' });
+    }
+  };
+
+  private handleClearApiKey = () => {
+    this.props.onSaveApiKey(undefined);
   };
 
   private handleApply = () => {

--- a/tracker/app/transactions/components/AmazonImportDialog.tsx
+++ b/tracker/app/transactions/components/AmazonImportDialog.tsx
@@ -37,10 +37,10 @@ async function shortenDescription(items: string, apiKey: string): Promise<string
     const resp = await fetch('https://api.anthropic.com/v1/messages', {
       method: 'POST',
       headers: {
-        'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01',
-        'anthropic-dangerous-direct-browser-access': 'true',
-        'content-type': 'application/json',
+        ['x-api-key']: apiKey,
+        ['anthropic-version']: '2023-06-01',
+        ['anthropic-dangerous-direct-browser-access']: 'true',
+        ['content-type']: 'application/json',
       },
       body: JSON.stringify({
         model: 'claude-haiku-4-5-20251001',


### PR DESCRIPTION
- Fix corepack/yarn cache detection in GitHub Actions CI
- Commit .yarnrc.yml so CI uses node-modules linker (fixes ts-jest with yarn 4 PnP)
- Add optional Anthropic API key stored in settings.json on Dropbox; shortens Amazon product descriptions via claude-haiku-4-5 during CSV import

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWthFdMWeKBJFQLFR2wHMT)_