### PR TITLE
fetch-server: show past week of runs, add per-run reparse button

### DIFF
--- a/fetch-server/db.py
+++ b/fetch-server/db.py
@@ -1,5 +1,5 @@
 import sqlite3
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 
@@ -89,9 +89,11 @@ def finish_run(
     conn.commit()
 
 
-def get_recent_runs(conn: sqlite3.Connection, limit: int = 20) -> list:
+def get_recent_runs(conn: sqlite3.Connection, days: int = 7) -> list:
+    since = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
     return conn.execute(
-        "SELECT * FROM fetch_runs ORDER BY started_at DESC LIMIT ?", (limit,)
+        "SELECT * FROM fetch_runs WHERE started_at >= ? ORDER BY started_at DESC",
+        (since,),
     ).fetchall()
 
 
@@ -172,6 +174,17 @@ def reset_parsed_emails(conn: sqlite3.Connection) -> int:
     cur = conn.execute(
         "UPDATE emails SET parse_status = 'pending', parsed_at = NULL, parse_error = NULL "
         "WHERE parse_status = 'parsed'"
+    )
+    conn.commit()
+    return cur.rowcount
+
+
+def reset_parsed_emails_for_run(conn: sqlite3.Connection, run_id: int) -> int:
+    """Mark emails from a specific run back to pending. Returns the number reset."""
+    cur = conn.execute(
+        "UPDATE emails SET parse_status = 'pending', parsed_at = NULL, parse_error = NULL "
+        "WHERE fetch_run_id = ? AND parse_status IN ('parsed', 'error', 'skipped')",
+        (run_id,),
     )
     conn.commit()
     return cur.rowcount

--- a/fetch-server/server.py
+++ b/fetch-server/server.py
@@ -187,6 +187,13 @@ async def reparse():
     return RedirectResponse(f'/?reparsing={count}', status_code=303)
 
 
+@app.post('/reparse/{run_id}')
+async def reparse_run(run_id: int):
+    count = db.reset_parsed_emails_for_run(_conn, run_id)
+    threading.Thread(target=_do_run, daemon=True).start()
+    return RedirectResponse(f'/run/{run_id}?reparsing={count}', status_code=303)
+
+
 def _restarting_html(git_hash: str, changed: bool) -> str:
     if changed:
         subtitle = f'Pulled new code &mdash; <code>{git_hash}</code>'

--- a/fetch-server/templates/run.html
+++ b/fetch-server/templates/run.html
@@ -20,11 +20,25 @@
     .badge-pending { background: #fff3cd; color: #856404; }
     .badge-skipped { background: #e2e3e5; color: #383d41; }
     .error-text { color: #721c24; font-size: 0.8rem; }
+    .actions { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; }
+    button.danger { padding: 0.5rem 1rem; font-size: 1rem; cursor: pointer; border: 1px solid #aa2200; border-radius: 4px; background: #cc3300; color: #fff; }
+    .notice { background: #fff3cd; border: 1px solid #ffc107; border-radius: 4px; padding: 0.5rem 1rem; margin-bottom: 1rem; }
   </style>
 </head>
 <body>
   <a class="back" href="/">← Back</a>
   <h1>Run #{{ run.id }}</h1>
+
+  {% if request.query_params.get('reparsing') %}
+  <div class="notice">Re-parsing {{ request.query_params.get('reparsing') }} emails from this run — run started.</div>
+  {% endif %}
+
+  <div class="actions">
+    <form method="post" action="/reparse/{{ run.id }}">
+      <button class="danger">Re-parse This Run's Emails</button>
+    </form>
+  </div>
+
   <div class="meta">
     {{ run.started_at[:19].replace('T', ' ') }} UTC ·
     <strong>{{ run.status }}</strong> ·


### PR DESCRIPTION
## Summary

- **Recent runs window:** `get_recent_runs` now returns all runs from the past 7 days instead of a fixed limit of 20. A quiet week still shows everything; a busy week doesn't get truncated arbitrarily.
- **Per-run reparse:** Run detail page gets a red "Re-parse This Run's Emails" button. It resets only that run's emails to `pending` (including `error` and `skipped` ones) and fires a new pipeline run — no need to nuke all email history just to fix one batch.

## Test plan

- [ ] Index page shows runs spanning the past week, not just the most recent 20
- [ ] Clicking "Re-parse This Run's Emails" on a run detail page shows the yellow notice and starts a new run
- [ ] Only emails from that run are reset; emails from other runs are unaffected
- [ ] Global "Re-parse All Emails" on the index page still works as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqYkfpkSi2aTZabQX4MDHg)_