### PR TITLE
fetch-server: fix race condition where stale frontend save loses transactions

### DIFF
--- a/fetch-server/test_pipeline.py
+++ b/fetch-server/test_pipeline.py
@@ -205,6 +205,15 @@ def test_merge_different_dates_not_deduped():
     assert len(added) == 1
 
 
+def test_merge_ofx_same_description_not_deduped_by_description():
+    # OFX transactions skip description-based dedup: identical same-day charges
+    # from a CSV import are legitimate and distinguished only by ID.
+    existing = [_tx('a', description='AMAZON', source='ofx_chase')]
+    new = [_tx('b', description='AMAZON', source='ofx_chase')]
+    added = _merge(existing, new, lambda _: None)
+    assert len(added) == 1
+
+
 def test_merge_sorts_by_date_descending():
     existing = [_tx('a', date='2026-01-01')]
     _merge(existing, [_tx('b', date='2026-03-01'), _tx('c', date='2025-06-01')], lambda _: None)

--- a/fetch-server/test_pipeline.py
+++ b/fetch-server/test_pipeline.py
@@ -254,11 +254,11 @@ class _FakeDropboxModule:
 
 
 def test_sync_uploads_new_transaction(monkeypatch):
-    mod = _FakeDropboxModule([_tx('existing')])
+    mod = _FakeDropboxModule([_tx('existing', description='OLD CHARGE')])
     import pipeline
     monkeypatch.setattr(pipeline, 'dropbox_module', mod)
 
-    added = sync_to_dropbox([_tx('new')], 'tok', '/p', lambda _: None)
+    added = sync_to_dropbox([_tx('new', description='NEW CHARGE')], 'tok', '/p', lambda _: None)
 
     assert len(added) == 1
     assert added[0]['id'] == 'new'
@@ -266,11 +266,11 @@ def test_sync_uploads_new_transaction(monkeypatch):
 
 
 def test_sync_no_upload_when_nothing_new(monkeypatch):
-    mod = _FakeDropboxModule([_tx('a')])
+    mod = _FakeDropboxModule([_tx('a', description='CHARGE A')])
     import pipeline
     monkeypatch.setattr(pipeline, 'dropbox_module', mod)
 
-    added = sync_to_dropbox([_tx('a')], 'tok', '/p', lambda _: None)
+    added = sync_to_dropbox([_tx('a', description='CHARGE A')], 'tok', '/p', lambda _: None)
 
     assert added == []
     assert mod._dbx.upload_calls == 0
@@ -279,11 +279,14 @@ def test_sync_no_upload_when_nothing_new(monkeypatch):
 def test_sync_restores_transaction_missing_after_stale_save(monkeypatch):
     """When a previously added transaction is absent from Dropbox (stale frontend
     save overwrote it), passing it back in new_transactions restores it."""
-    mod = _FakeDropboxModule([_tx('kept')])  # 'lost' is not here
+    mod = _FakeDropboxModule([_tx('kept', description='KEPT CHARGE')])
     import pipeline
     monkeypatch.setattr(pipeline, 'dropbox_module', mod)
 
-    added = sync_to_dropbox([_tx('lost'), _tx('kept')], 'tok', '/p', lambda _: None)
+    added = sync_to_dropbox(
+        [_tx('lost', description='LOST CHARGE'), _tx('kept', description='KEPT CHARGE')],
+        'tok', '/p', lambda _: None,
+    )
 
     assert len(added) == 1
     assert added[0]['id'] == 'lost'


### PR DESCRIPTION
## Summary

Fixes a race condition where a stale frontend save could silently overwrite transactions the fetch-server had already added to Dropbox:

1. **Root cause**: The frontend loads `transactions.json` once at login and saves with a full overwrite. If the fetch-server runs while the frontend is open, the next frontend save loses any transactions added in between.

2. **Fix** (`db.py`, `pipeline.py`): On each hourly run, the fetch-server now loads the transactions it added in the last 7 days from SQLite and re-includes them in the merge. `_merge` deduplicates by ID, so in the normal case they're silently skipped with no extra upload. If a stale frontend save wiped them out, they're restored automatically.

3. **Tests** (`test_db.py`): Covers `get_recently_added_transactions` — returning from recent successful runs, excluding failed/old/null runs, and deduplication across runs.

4. **Tests** (`test_pipeline.py`): Covers `sync_to_dropbox` with a mock Dropbox — uploads only when needed, no upload when already up-to-date, and restores a transaction that was absent due to a stale frontend save. Also adds the OFX dedup test in this PR.

## Test plan

- [ ] CI passes (`pytest` discovers and runs both `test_pipeline.py` and `test_db.py`)
- [ ] `test_recently_added_*` tests confirm the 7-day window, dedup, and error-run exclusion logic
- [ ] `test_sync_restores_transaction_missing_after_stale_save` confirms the core race condition fix
- [ ] `test_merge_ofx_same_description_not_deduped_by_description` confirms OFX CSV imports allow same-description transactions

https://claude.ai/code/session_01DWthFdMWeKBJFQLFR2wHMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWthFdMWeKBJFQLFR2wHMT)_