### PR TITLE
Soft-delete transactions using 'deleted' tag to prevent fetch-server re-adding

### DIFF
--- a/fetch-server/test_pipeline.py
+++ b/fetch-server/test_pipeline.py
@@ -205,6 +205,15 @@ def test_merge_different_dates_not_deduped():
     assert len(added) == 1
 
 
+def test_merge_does_not_readd_soft_deleted_transaction():
+    # A transaction soft-deleted in the frontend (deleted=True) stays in
+    # existing, so its ID remains in seen_ids and _merge won't re-add it.
+    existing = [{**_tx('a'), 'deleted': True}]
+    added = _merge(existing, [_tx('a')], lambda _: None)
+    assert added == []
+    assert len(existing) == 1
+
+
 def test_merge_ofx_same_description_not_deduped_by_description():
     # OFX transactions skip description-based dedup: identical same-day charges
     # from a CSV import are legitimate and distinguished only by ID.

--- a/fetch-server/test_pipeline.py
+++ b/fetch-server/test_pipeline.py
@@ -162,14 +162,14 @@ def test_unknown_email_raises():
 
 # ── Merge / dedup ──────────────────────────────────────────────────────────────
 
-def _tx(id, date='2026-04-27', description='STORE', source='email_usaa', amount_cents=1000):
+def _tx(id, date='2026-04-27', description='STORE', source='email_usaa', amount_cents=1000, tags=None):
     return {
         'id': id,
         'date': date,
         'description': description,
         'source': source,
         'amount_cents': amount_cents,
-        'tags': [],
+        'tags': tags if tags is not None else [],
         'transactions': [],
         'notes': '',
         'original_line': 'subject',
@@ -206,9 +206,9 @@ def test_merge_different_dates_not_deduped():
 
 
 def test_merge_does_not_readd_soft_deleted_transaction():
-    # A transaction soft-deleted in the frontend (deleted=True) stays in
-    # existing, so its ID remains in seen_ids and _merge won't re-add it.
-    existing = [{**_tx('a'), 'deleted': True}]
+    # A transaction deleted in the frontend (tagged 'deleted') stays in existing,
+    # so its ID remains in seen_ids and _merge won't re-add it.
+    existing = [_tx('a', tags=['deleted'])]
     added = _merge(existing, [_tx('a')], lambda _: None)
     assert added == []
     assert len(existing) == 1

--- a/tracker/app/main/components/Editor.tsx
+++ b/tracker/app/main/components/Editor.tsx
@@ -456,12 +456,11 @@ class EditorInner extends React.Component<IEditorInnerProps, IEditorState> {
   private handleDeleteTransactions = (
     transactionsToDelete: Map<string, Transactions.ITransaction>
   ): void => {
-    let transactionsToKeep = this.props.transactions.filter(
-      (t: Transactions.ITransaction) => {
-        return !transactionsToDelete.has(t.id);
-      }
+    const updated = this.props.transactions.map(
+      (t: Transactions.ITransaction) =>
+        transactionsToDelete.has(t.id) ? { ...t, deleted: true as const } : t
     );
-    this.props.updateTransactions(transactionsToKeep);
+    this.props.updateTransactions(updated);
     this.setState({
       selectedTransactions: new Map(),
     });

--- a/tracker/app/main/components/Editor.tsx
+++ b/tracker/app/main/components/Editor.tsx
@@ -458,7 +458,9 @@ class EditorInner extends React.Component<IEditorInnerProps, IEditorState> {
   ): void => {
     const updated = this.props.transactions.map(
       (t: Transactions.ITransaction) =>
-        transactionsToDelete.has(t.id) ? { ...t, deleted: true as const } : t
+        transactionsToDelete.has(t.id)
+          ? { ...t, tags: [...t.tags, 'deleted'] }
+          : t
     );
     this.props.updateTransactions(updated);
     this.setState({

--- a/tracker/app/transactions/__test__/utils.spec.ts
+++ b/tracker/app/transactions/__test__/utils.spec.ts
@@ -229,4 +229,53 @@ describe('Home', () => {
     });
     expect(filtered.length).toBe(1);
   });
+
+  it('filterTransactions excludes soft-deleted transactions', () => {
+    const tx = (id: string, deleted?: true): ITransaction => ({
+      id,
+      description: `Merchant ${id}`,
+      original_line: '',
+      date: '2019-01-05',
+      tags: [],
+      amount_cents: 100,
+      transactions: [],
+      ...(deleted ? { deleted } : {}),
+    });
+
+    const transactions = [tx('1'), tx('2', true), tx('3'), tx('4', true), tx('5')];
+
+    const filtered = utils.filterTransactions(transactions, {});
+    expect(filtered.length).toBe(3);
+    expect(filtered.map(t => t.id)).toEqual(['1', '3', '5']);
+  });
+
+  it('filterTransactions applies other filters after excluding deleted', () => {
+    const tx = (
+      id: string,
+      tags: string[],
+      deleted?: true
+    ): ITransaction => ({
+      id,
+      description: `Merchant ${id}`,
+      original_line: '',
+      date: '2019-01-05',
+      tags,
+      amount_cents: 100,
+      transactions: [],
+      ...(deleted ? { deleted } : {}),
+    });
+
+    const transactions = [
+      tx('1', ['groceries']),
+      tx('2', ['groceries'], true), // deleted — must not appear even with matching tag
+      tx('3', ['gas']),
+      tx('4', ['groceries']),
+    ];
+
+    const filtered = utils.filterTransactions(transactions, {
+      tagsIncludeAll: ['groceries'],
+    });
+    expect(filtered.length).toBe(2);
+    expect(filtered.map(t => t.id)).toEqual(['1', '4']);
+  });
 });

--- a/tracker/app/transactions/__test__/utils.spec.ts
+++ b/tracker/app/transactions/__test__/utils.spec.ts
@@ -230,31 +230,8 @@ describe('Home', () => {
     expect(filtered.length).toBe(1);
   });
 
-  it('filterTransactions excludes soft-deleted transactions', () => {
-    const tx = (id: string, deleted?: true): ITransaction => ({
-      id,
-      description: `Merchant ${id}`,
-      original_line: '',
-      date: '2019-01-05',
-      tags: [],
-      amount_cents: 100,
-      transactions: [],
-      ...(deleted ? { deleted } : {}),
-    });
-
-    const transactions = [tx('1'), tx('2', true), tx('3'), tx('4', true), tx('5')];
-
-    const filtered = utils.filterTransactions(transactions, {});
-    expect(filtered.length).toBe(3);
-    expect(filtered.map(t => t.id)).toEqual(['1', '3', '5']);
-  });
-
-  it('filterTransactions applies other filters after excluding deleted', () => {
-    const tx = (
-      id: string,
-      tags: string[],
-      deleted?: true
-    ): ITransaction => ({
+  it('filterTransactions excludes transactions tagged deleted', () => {
+    const tx = (id: string, tags: string[] = []): ITransaction => ({
       id,
       description: `Merchant ${id}`,
       original_line: '',
@@ -262,12 +239,35 @@ describe('Home', () => {
       tags,
       amount_cents: 100,
       transactions: [],
-      ...(deleted ? { deleted } : {}),
+    });
+
+    const transactions = [
+      tx('1'),
+      tx('2', ['deleted']),
+      tx('3'),
+      tx('4', ['deleted']),
+      tx('5'),
+    ];
+
+    const filtered = utils.filterTransactions(transactions, {});
+    expect(filtered.length).toBe(3);
+    expect(filtered.map(t => t.id)).toEqual(['1', '3', '5']);
+  });
+
+  it('filterTransactions excludes deleted even when other tags match filters', () => {
+    const tx = (id: string, tags: string[]): ITransaction => ({
+      id,
+      description: `Merchant ${id}`,
+      original_line: '',
+      date: '2019-01-05',
+      tags,
+      amount_cents: 100,
+      transactions: [],
     });
 
     const transactions = [
       tx('1', ['groceries']),
-      tx('2', ['groceries'], true), // deleted — must not appear even with matching tag
+      tx('2', ['groceries', 'deleted']), // deleted — must not appear even with matching tag
       tx('3', ['gas']),
       tx('4', ['groceries']),
     ];

--- a/tracker/app/transactions/model.ts
+++ b/tracker/app/transactions/model.ts
@@ -75,7 +75,6 @@ export interface ITransaction {
   transactions: Array<ITransaction>;
   source?: string;
   notes?: string;
-  deleted?: true;
 }
 
 export interface ITransactionsState {

--- a/tracker/app/transactions/model.ts
+++ b/tracker/app/transactions/model.ts
@@ -75,6 +75,7 @@ export interface ITransaction {
   transactions: Array<ITransaction>;
   source?: string;
   notes?: string;
+  deleted?: true;
 }
 
 export interface ITransactionsState {

--- a/tracker/app/transactions/utils.ts
+++ b/tracker/app/transactions/utils.ts
@@ -205,7 +205,9 @@ export function filterTransactions(
   if (!transactions.length) {
     return [];
   }
-  let filteredTransactions: ITransaction[] = transactions;
+  let filteredTransactions: ITransaction[] = transactions.filter(
+    t => !t.deleted
+  );
   if (filters.startDate || filters.endDate) {
     filteredTransactions = filterTransactionsByDate(
       filteredTransactions,

--- a/tracker/app/transactions/utils.ts
+++ b/tracker/app/transactions/utils.ts
@@ -206,7 +206,7 @@ export function filterTransactions(
     return [];
   }
   let filteredTransactions: ITransaction[] = transactions.filter(
-    t => !t.deleted
+    t => !t.tags.includes('deleted')
   );
   if (filters.startDate || filters.endDate) {
     filteredTransactions = filterTransactionsByDate(


### PR DESCRIPTION
## Summary

- When the user deletes a transaction in the Editor, it now adds a `'deleted'` tag instead of removing it from `transactions.json`. The transaction stays in the array so the fetch-server's `_merge` sees its ID in `existing` and won't re-add it on the next run.
- `filterTransactions()` filters out `tags.includes('deleted')` before any other filter, so deleted transactions are invisible in all views (Daily, Monthly, Report, Editor).
- No fetch-server changes needed — the existing dedup-by-ID logic handles this correctly.
- Reuses the existing tag system rather than adding a new field to `ITransaction`.

## Test plan

- [ ] CI passes (tracker + fetch-server)
- [ ] `filterTransactions excludes transactions tagged deleted` — deleted transactions hidden with no filters
- [ ] `filterTransactions excludes deleted even when other tags match filters` — deleted not shown even if other tags match
- [ ] `test_merge_does_not_readd_soft_deleted_transaction` — fetch-server won't re-add a transaction tagged deleted

https://claude.ai/code/session_01DWthFdMWeKBJFQLFR2wHMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWthFdMWeKBJFQLFR2wHMT)_