### PR TITLE
Fix overlapping amount fields in split transaction dialog

### DIFF
--- a/tracker/app/transactions/components/SplitTransactionDialog.tsx
+++ b/tracker/app/transactions/components/SplitTransactionDialog.tsx
@@ -15,10 +15,10 @@ import TransactionsTable from './TransactionsTable';
 const useStyles = makeStyles()((_theme: Theme) => ({
   amount: {
     flex: '0 0 80px',
-    // This fixes the vertical alignment of the input.
-    paddingTop: '8px',
     '& input': {
       textAlign: 'right',
+      paddingTop: '8.5px',
+      paddingBottom: '8.5px',
     },
   },
   dialogContent: {


### PR DESCRIPTION
Merging previewed changes to main. See #113 for details.

https://claude.ai/code/session_01DWthFdMWeKBJFQLFR2wHMT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWthFdMWeKBJFQLFR2wHMT)_