### PR TITLE
fetch-server: add prod site link to daily summary email

### DIFF
--- a/fetch-server/server.py
+++ b/fetch-server/server.py
@@ -87,6 +87,7 @@ def _send_daily_summary():
     for t in transactions:
         amount = t['amount_cents'] / 100
         lines.append(f'  {t["date"]}  {t["description"]:<40}  ${amount:>8.2f}')
+    lines.append('\nhttps://spent-xi.vercel.app')
 
     body = '\n'.join(lines)
     subject = f'Spent: {count} new transaction{"s" if count != 1 else ""}'


### PR DESCRIPTION
Appends `https://spent-xi.vercel.app` to the bottom of the daily summary email body so you can tap straight through to the tracker.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqYkfpkSi2aTZabQX4MDHg)_