### PR TITLE
tracker: add brokerage tax estimate page (Federal + California, 2025 MFJ)

### DIFF
--- a/tracker/app/brokerage/components/BrokeragePage.tsx
+++ b/tracker/app/brokerage/components/BrokeragePage.tsx
@@ -27,6 +27,7 @@ import {
   parseSchwebEquityCsv,
 } from '../csvParser';
 import { calculateTax } from '../taxCalculator';
+import QUALIFIED_DIVIDEND_LOOKUP from '../qualifiedDividendLookup';
 
 // ── Styles ────────────────────────────────────────────────────────────────────
 
@@ -268,6 +269,20 @@ export default function BrokeragePage() {
       ...prev.filter(t => t.source !== source),
       ...parsed,
     ]);
+    // Auto-populate qualified % from lookup for dividend symbols not yet configured.
+    const newDividendSymbols = [...new Set(parsed
+      .filter(t => t.category === 'dividend' && t.symbol)
+      .map(t => t.symbol),
+    )];
+    setQualifiedConfig(prev => {
+      const updates: IQualifiedConfig = {};
+      for (const sym of newDividendSymbols) {
+        if (!(sym in prev) && sym in QUALIFIED_DIVIDEND_LOOKUP) {
+          updates[sym] = QUALIFIED_DIVIDEND_LOOKUP[sym];
+        }
+      }
+      return Object.keys(updates).length > 0 ? { ...prev, ...updates } : prev;
+    });
   };
 
   const handleQualifiedChange = (symbol: string, value: string) => {
@@ -338,8 +353,8 @@ export default function BrokeragePage() {
               Qualified Dividend % by Fund
             </Typography>
             <Typography variant="body2" color="text.secondary" gutterBottom>
-              Enter the qualified percentage from your prior-year 1099-DIV.
-              Bond funds = 0%. Stock ETFs are typically 80–100%. Saved in browser.
+              Known funds are pre-filled from prior-year estimates. Override any value or
+              enter a percentage from your 1099-DIV for unlisted symbols. Saved in browser.
             </Typography>
             {dividendSymbols.map(symbol => (
               <div key={symbol} className={classes.qualifiedRow}>

--- a/tracker/app/brokerage/components/BrokeragePage.tsx
+++ b/tracker/app/brokerage/components/BrokeragePage.tsx
@@ -1,0 +1,459 @@
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
+import InputAdornment from '@mui/material/InputAdornment';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
+import { makeStyles } from 'tss-react/mui';
+import { Theme } from '@mui/material/styles';
+import * as React from 'react';
+import MenuBarWithDrawer from '../../main/components/MenuBarWithDrawer';
+import {
+  IBrokerageTransaction,
+  IQualifiedConfig,
+  ITaxSummary,
+} from '../model';
+import {
+  parseVanguardCsv,
+  parseSchwebCsv,
+  parseSchwebEquityCsv,
+} from '../csvParser';
+import { calculateTax } from '../taxCalculator';
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+const useStyles = makeStyles()((_theme: Theme) => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+  },
+  content: {
+    flex: 1,
+    overflow: 'auto',
+    padding: '16px',
+    maxWidth: '900px',
+    margin: '0 auto',
+    width: '100%',
+    boxSizing: 'border-box',
+  },
+  section: {
+    marginBottom: '24px',
+  },
+  sectionTitle: {
+    marginBottom: '12px',
+    fontWeight: 600,
+  },
+  uploadRow: {
+    display: 'flex',
+    gap: '12px',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+  },
+  uploadButton: {
+    textTransform: 'none',
+  },
+  chip: {
+    marginLeft: '8px',
+  },
+  warningText: {
+    color: '#856404',
+    fontSize: '0.85rem',
+    marginTop: '6px',
+  },
+  table: {
+    fontSize: '0.85rem',
+  },
+  summaryPaper: {
+    padding: '16px',
+  },
+  summaryRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: '4px 0',
+  },
+  summaryTotal: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: '8px 0',
+    fontWeight: 700,
+    borderTop: '2px solid #ccc',
+    marginTop: '4px',
+  },
+  positive: { color: '#155724' },
+  negative: { color: '#721c24' },
+  qualifiedRow: {
+    display: 'flex',
+    gap: '12px',
+    alignItems: 'center',
+    marginBottom: '8px',
+    flexWrap: 'wrap',
+  },
+  qualifiedSymbol: {
+    minWidth: '80px',
+    fontWeight: 600,
+    fontFamily: 'monospace',
+  },
+  qualifiedField: {
+    width: '120px',
+  },
+  emptyState: {
+    color: '#999',
+    fontStyle: 'italic',
+    padding: '16px 0',
+  },
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const QUALIFIED_CONFIG_KEY = 'brokerage:qualifiedConfig';
+
+function loadQualifiedConfig(): IQualifiedConfig {
+  try {
+    const stored = localStorage.getItem(QUALIFIED_CONFIG_KEY);
+    return stored ? (JSON.parse(stored) as IQualifiedConfig) : {};
+  } catch {
+    return {};
+  }
+}
+
+function fmt(cents: number): string {
+  const abs = Math.abs(cents) / 100;
+  const str = abs.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+  return cents < 0 ? `($${str})` : `$${str}`;
+}
+
+function categoryLabel(cat: IBrokerageTransaction['category']): string {
+  switch (cat) {
+    case 'dividend': return 'Dividend';
+    case 'interest': return 'Interest';
+    case 'ltcg':     return 'LT Gain';
+    case 'stcg':     return 'ST Gain';
+  }
+}
+
+function sourceLabel(src: IBrokerageTransaction['source']): string {
+  switch (src) {
+    case 'vanguard':     return 'Vanguard';
+    case 'schwab':       return 'Schwab';
+    case 'schwab_equity': return 'Schwab RSU';
+  }
+}
+
+// ── Upload button ─────────────────────────────────────────────────────────────
+
+interface IUploadButtonProps {
+  label: string;
+  count: number;
+  onFile: (text: string) => void;
+}
+
+function UploadButton({ label, count, onFile }: IUploadButtonProps) {
+  const { classes } = useStyles();
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = ev => onFile(ev.target?.result as string ?? '');
+    reader.readAsText(file);
+    // Reset so the same file can be re-uploaded
+    e.target.value = '';
+  };
+
+  return (
+    <Box display="flex" alignItems="center">
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".csv"
+        style={{ display: 'none' }}
+        onChange={handleChange}
+      />
+      <Button
+        className={classes.uploadButton}
+        variant="outlined"
+        startIcon={<UploadFileIcon />}
+        onClick={() => inputRef.current?.click()}
+      >
+        {label}
+      </Button>
+      {count > 0 && (
+        <Chip
+          className={classes.chip}
+          label={`${count} transaction${count !== 1 ? 's' : ''}`}
+          size="small"
+          color="success"
+          variant="outlined"
+        />
+      )}
+    </Box>
+  );
+}
+
+// ── Summary row helper ────────────────────────────────────────────────────────
+
+function SummaryRow({ label, cents, indent }: { label: string; cents: number; indent?: boolean }) {
+  const { classes } = useStyles();
+  return (
+    <div className={classes.summaryRow} style={indent ? { paddingLeft: '16px' } : undefined}>
+      <Typography variant="body2">{label}</Typography>
+      <Typography variant="body2" className={cents < 0 ? classes.negative : undefined}>
+        {fmt(cents)}
+      </Typography>
+    </div>
+  );
+}
+
+function SummaryTotal({ label, cents }: { label: string; cents: number }) {
+  const { classes } = useStyles();
+  return (
+    <div className={classes.summaryTotal}>
+      <Typography variant="body1">{label}</Typography>
+      <Typography variant="body1">{fmt(cents)}</Typography>
+    </div>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function BrokeragePage() {
+  const { classes } = useStyles();
+  const [transactions, setTransactions] = React.useState<IBrokerageTransaction[]>([]);
+  const [qualifiedConfig, setQualifiedConfig] = React.useState<IQualifiedConfig>(loadQualifiedConfig);
+
+  // Persist qualified config to localStorage on change
+  React.useEffect(() => {
+    localStorage.setItem(QUALIFIED_CONFIG_KEY, JSON.stringify(qualifiedConfig));
+  }, [qualifiedConfig]);
+
+  const countBySource = React.useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const t of transactions) {
+      counts[t.source] = (counts[t.source] ?? 0) + 1;
+    }
+    return counts;
+  }, [transactions]);
+
+  const dividendSymbols = React.useMemo(() => {
+    const syms = new Set<string>();
+    for (const t of transactions) {
+      if (t.category === 'dividend' && t.symbol) syms.add(t.symbol);
+    }
+    return Array.from(syms).sort();
+  }, [transactions]);
+
+  const taxSummary: ITaxSummary | null = React.useMemo(() => {
+    if (transactions.length === 0) return null;
+    return calculateTax(transactions, qualifiedConfig);
+  }, [transactions, qualifiedConfig]);
+
+  const addTransactions = (
+    parser: (text: string) => IBrokerageTransaction[],
+    source: IBrokerageTransaction['source'],
+  ) => (text: string) => {
+    const parsed = parser(text);
+    setTransactions(prev => [
+      ...prev.filter(t => t.source !== source),
+      ...parsed,
+    ]);
+  };
+
+  const handleQualifiedChange = (symbol: string, value: string) => {
+    const pct = parseFloat(value);
+    if (isNaN(pct)) return;
+    setQualifiedConfig(prev => ({ ...prev, [symbol]: Math.min(1, Math.max(0, pct / 100)) }));
+  };
+
+  // Sort transactions newest first for display
+  const sortedTransactions = React.useMemo(
+    () => [...transactions].sort((a, b) => b.date.localeCompare(a.date)),
+    [transactions],
+  );
+
+  return (
+    <div className={classes.root}>
+      <MenuBarWithDrawer title="Tax Estimates" />
+      <div className={classes.content}>
+        <Typography variant="body2" color="text.secondary" gutterBottom>
+          2025 Federal + California estimate · Married Filing Jointly · All figures approximate
+        </Typography>
+
+        {/* ── Import ── */}
+        <div className={classes.section}>
+          <Typography variant="h6" className={classes.sectionTitle}>Import CSVs</Typography>
+          <div className={classes.uploadRow}>
+            <UploadButton
+              label="Vanguard"
+              count={countBySource['vanguard'] ?? 0}
+              onFile={addTransactions(parseVanguardCsv, 'vanguard')}
+            />
+            <UploadButton
+              label="Schwab"
+              count={countBySource['schwab'] ?? 0}
+              onFile={addTransactions(parseSchwebCsv, 'schwab')}
+            />
+            <UploadButton
+              label="Schwab RSU"
+              count={countBySource['schwab_equity'] ?? 0}
+              onFile={addTransactions(parseSchwebEquityCsv, 'schwab_equity')}
+            />
+            {transactions.length > 0 && (
+              <Button
+                size="small"
+                color="error"
+                onClick={() => setTransactions([])}
+              >
+                Clear all
+              </Button>
+            )}
+          </div>
+          <Typography className={classes.warningText}>
+            Note: Vanguard and Schwab fund sells are not included (cost basis not in CSV export).
+            Enter those gains manually or use the 1099-B.
+          </Typography>
+        </div>
+
+        {transactions.length === 0 && (
+          <Typography className={classes.emptyState}>
+            Upload one or more CSVs to see transactions and tax estimates.
+          </Typography>
+        )}
+
+        {/* ── Qualified dividend config ── */}
+        {dividendSymbols.length > 0 && (
+          <div className={classes.section}>
+            <Typography variant="h6" className={classes.sectionTitle}>
+              Qualified Dividend % by Fund
+            </Typography>
+            <Typography variant="body2" color="text.secondary" gutterBottom>
+              Enter the qualified percentage from your prior-year 1099-DIV.
+              Bond funds = 0%. Stock ETFs are typically 80–100%. Saved in browser.
+            </Typography>
+            {dividendSymbols.map(symbol => (
+              <div key={symbol} className={classes.qualifiedRow}>
+                <Typography className={classes.qualifiedSymbol}>{symbol}</Typography>
+                <TextField
+                  className={classes.qualifiedField}
+                  size="small"
+                  type="number"
+                  inputProps={{ min: 0, max: 100, step: 1 }}
+                  InputProps={{
+                    endAdornment: <InputAdornment position="end">%</InputAdornment>,
+                  }}
+                  value={Math.round((qualifiedConfig[symbol] ?? 0) * 100)}
+                  onChange={e => handleQualifiedChange(symbol, e.target.value)}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* ── Tax summary ── */}
+        {taxSummary && (
+          <div className={classes.section}>
+            <Typography variant="h6" className={classes.sectionTitle}>Tax Summary</Typography>
+            <Paper className={classes.summaryPaper} variant="outlined">
+              <Typography variant="subtitle2" gutterBottom>Income</Typography>
+              <SummaryRow label="Ordinary dividends" cents={taxSummary.ordinaryDividendsCents} />
+              <SummaryRow label="Qualified dividends" cents={taxSummary.qualifiedDividendsCents} />
+              <SummaryRow label="Interest" cents={taxSummary.interestCents} />
+              <SummaryRow label="Short-term gains" cents={taxSummary.stcgCents} />
+              <SummaryRow label="Long-term gains" cents={taxSummary.ltcgCents} />
+
+              <Divider sx={{ my: 1.5 }} />
+
+              <Typography variant="subtitle2" gutterBottom>Federal</Typography>
+              <SummaryRow
+                label={`Standard deduction`}
+                cents={-taxSummary.federalStandardDeductionCents}
+              />
+              <SummaryRow
+                label="Ordinary income tax"
+                cents={taxSummary.federalOrdinaryTaxCents}
+                indent
+              />
+              <SummaryRow
+                label="LTCG / qualified dividend tax"
+                cents={taxSummary.federalLtcgTaxCents}
+                indent
+              />
+              {taxSummary.federalNiitCents > 0 && (
+                <SummaryRow
+                  label="NIIT (3.8%)"
+                  cents={taxSummary.federalNiitCents}
+                  indent
+                />
+              )}
+              <SummaryTotal label="Federal total" cents={taxSummary.federalTotalCents} />
+
+              <Divider sx={{ my: 1.5 }} />
+
+              <Typography variant="subtitle2" gutterBottom>California</Typography>
+              <SummaryRow
+                label="Standard deduction"
+                cents={-taxSummary.caStandardDeductionCents}
+              />
+              <SummaryRow
+                label="CA income tax (all ordinary)"
+                cents={taxSummary.caTaxCents}
+                indent
+              />
+              <SummaryTotal label="CA total" cents={taxSummary.caTaxCents} />
+
+              <Divider sx={{ my: 1.5 }} />
+              <SummaryTotal label="Total estimated tax" cents={taxSummary.totalTaxCents} />
+            </Paper>
+          </div>
+        )}
+
+        {/* ── Transactions table ── */}
+        {sortedTransactions.length > 0 && (
+          <div className={classes.section}>
+            <Typography variant="h6" className={classes.sectionTitle}>
+              Transactions ({sortedTransactions.length})
+            </Typography>
+            <Table size="small" className={classes.table}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Date</TableCell>
+                  <TableCell>Source</TableCell>
+                  <TableCell>Symbol</TableCell>
+                  <TableCell>Description</TableCell>
+                  <TableCell>Category</TableCell>
+                  <TableCell align="right">Amount</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {sortedTransactions.map((t, i) => (
+                  <TableRow key={i}>
+                    <TableCell>{t.date}</TableCell>
+                    <TableCell>{sourceLabel(t.source)}</TableCell>
+                    <TableCell sx={{ fontFamily: 'monospace' }}>{t.symbol}</TableCell>
+                    <TableCell>{t.description}</TableCell>
+                    <TableCell>{categoryLabel(t.category)}</TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{ color: t.amountCents < 0 ? '#721c24' : undefined }}
+                    >
+                      {fmt(t.amountCents)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/tracker/app/brokerage/components/BrokeragePage.tsx
+++ b/tracker/app/brokerage/components/BrokeragePage.tsx
@@ -1,4 +1,3 @@
-import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
@@ -21,11 +20,7 @@ import {
   IQualifiedConfig,
   ITaxSummary,
 } from '../model';
-import {
-  parseVanguardCsv,
-  parseSchwebCsv,
-  parseSchwebEquityCsv,
-} from '../csvParser';
+import { detectAndParseCsv } from '../csvParser';
 import { calculateTax } from '../taxCalculator';
 import qualifiedDividendLookup from '../qualifiedDividendLookup';
 
@@ -53,17 +48,32 @@ const useStyles = makeStyles()((_theme: Theme) => ({
     marginBottom: '12px',
     fontWeight: 600,
   },
+  dropZone: {
+    border: '2px dashed #ccc',
+    borderRadius: '8px',
+    padding: '24px',
+    textAlign: 'center' as const,
+    cursor: 'pointer',
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    gap: '6px',
+    transition: 'border-color 0.15s, background-color 0.15s',
+    '&:hover': {
+      borderColor: '#1976d2',
+      backgroundColor: 'rgba(25, 118, 210, 0.04)',
+    },
+  },
+  dropZoneActive: {
+    borderColor: '#1976d2',
+    backgroundColor: 'rgba(25, 118, 210, 0.08)',
+  },
   uploadRow: {
     display: 'flex',
-    gap: '12px',
+    gap: '8px',
     flexWrap: 'wrap',
     alignItems: 'center',
-  },
-  uploadButton: {
-    textTransform: 'none',
-  },
-  chip: {
-    marginLeft: '8px',
+    marginTop: '8px',
   },
   warningText: {
     color: '#856404',
@@ -151,59 +161,18 @@ function sourceLabel(src: IBrokerageTransaction['source']): string {
   }
 }
 
-// ── Upload button ─────────────────────────────────────────────────────────────
-
-interface IUploadButtonProps {
-  label: string;
-  count: number;
-  onFile: (text: string) => void;
+// Deduplicate by date + category + symbol + amount. Preserves first occurrence.
+function dedupe(txs: IBrokerageTransaction[]): IBrokerageTransaction[] {
+  const seen = new Set<string>();
+  return txs.filter(t => {
+    const key = `${t.date}|${t.category}|${t.symbol}|${t.amountCents}`;
+    if (seen.has(key)) { return false; }
+    seen.add(key);
+    return true;
+  });
 }
 
-function UploadButton({ label, count, onFile }: IUploadButtonProps) {
-  const { classes } = useStyles();
-  const inputRef = React.useRef<HTMLInputElement>(null);
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) {return;}
-    const reader = new FileReader();
-    reader.onload = ev => onFile(ev.target?.result as string ?? '');
-    reader.readAsText(file);
-    // Reset so the same file can be re-uploaded
-    e.target.value = '';
-  };
-
-  return (
-    <Box display="flex" alignItems="center">
-      <input
-        ref={inputRef}
-        type="file"
-        accept=".csv"
-        style={{ display: 'none' }}
-        onChange={handleChange}
-      />
-      <Button
-        className={classes.uploadButton}
-        variant="outlined"
-        startIcon={<UploadFileIcon />}
-        onClick={() => inputRef.current?.click()}
-      >
-        {label}
-      </Button>
-      {count > 0 && (
-        <Chip
-          className={classes.chip}
-          label={`${count} transaction${count !== 1 ? 's' : ''}`}
-          size="small"
-          color="success"
-          variant="outlined"
-        />
-      )}
-    </Box>
-  );
-}
-
-// ── Summary row helper ────────────────────────────────────────────────────────
+// ── Summary row helpers ───────────────────────────────────────────────────────
 
 function SummaryRow({ label, cents, indent }: { label: string; cents: number; indent?: boolean }) {
   const { classes } = useStyles();
@@ -233,6 +202,8 @@ export default function BrokeragePage() {
   const { classes } = useStyles();
   const [transactions, setTransactions] = React.useState<IBrokerageTransaction[]>([]);
   const [qualifiedConfig, setQualifiedConfig] = React.useState<IQualifiedConfig>(loadQualifiedConfig);
+  const [isDragging, setIsDragging] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   // Persist qualified config to localStorage on change
   React.useEffect(() => {
@@ -260,30 +231,31 @@ export default function BrokeragePage() {
     return calculateTax(transactions, qualifiedConfig);
   }, [transactions, qualifiedConfig]);
 
-  const addTransactions = (
-    parser: (text: string) => IBrokerageTransaction[],
-    source: IBrokerageTransaction['source'],
-  ) => (text: string) => {
-    const parsed = parser(text);
-    setTransactions(prev => [
-      ...prev.filter(t => t.source !== source),
-      ...parsed,
-    ]);
-    // Auto-populate qualified % from lookup for dividend symbols not yet configured.
-    const newDividendSymbols = [...new Set(parsed
-      .filter(t => t.category === 'dividend' && t.symbol)
-      .map(t => t.symbol),
-    )];
-    setQualifiedConfig(prev => {
-      const updates: IQualifiedConfig = {};
-      for (const sym of newDividendSymbols) {
-        if (!(sym in prev) && sym in qualifiedDividendLookup) {
-          updates[sym] = qualifiedDividendLookup[sym];
+  const handleFiles = React.useCallback((files: FileList) => {
+    const promises = Array.from(files).map(
+      file => new Promise<IBrokerageTransaction[]>(resolve => {
+        const reader = new FileReader();
+        reader.onload = ev => resolve(detectAndParseCsv(ev.target?.result as string ?? ''));
+        reader.readAsText(file);
+      }),
+    );
+    Promise.all(promises).then(results => {
+      const newTxs = results.flat();
+      setTransactions(prev => dedupe([...prev, ...newTxs]));
+      const newDivSymbols = [...new Set(
+        newTxs.filter(t => t.category === 'dividend' && t.symbol).map(t => t.symbol),
+      )];
+      setQualifiedConfig(prev => {
+        const updates: IQualifiedConfig = {};
+        for (const sym of newDivSymbols) {
+          if (!(sym in prev) && sym in qualifiedDividendLookup) {
+            updates[sym] = qualifiedDividendLookup[sym];
+          }
         }
-      }
-      return Object.keys(updates).length > 0 ? { ...prev, ...updates } : prev;
+        return Object.keys(updates).length > 0 ? { ...prev, ...updates } : prev;
+      });
     });
-  };
+  }, []);
 
   const handleQualifiedChange = (symbol: string, value: string) => {
     const pct = parseFloat(value);
@@ -308,28 +280,66 @@ export default function BrokeragePage() {
         {/* ── Import ── */}
         <div className={classes.section}>
           <Typography variant="h6" className={classes.sectionTitle}>Import CSVs</Typography>
+          <input
+            ref={inputRef}
+            type="file"
+            accept=".csv"
+            multiple
+            style={{ display: 'none' }}
+            onChange={e => {
+              if (e.target.files?.length) {handleFiles(e.target.files);}
+              e.target.value = '';
+            }}
+          />
+          <div
+            className={`${classes.dropZone}${isDragging ? ` ${classes.dropZoneActive}` : ''}`}
+            onClick={() => inputRef.current?.click()}
+            onDrop={e => {
+              e.preventDefault();
+              setIsDragging(false);
+              if (e.dataTransfer.files.length > 0) {handleFiles(e.dataTransfer.files);}
+            }}
+            onDragOver={e => e.preventDefault()}
+            onDragEnter={() => setIsDragging(true)}
+            onDragLeave={e => {
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) {setIsDragging(false);}
+            }}
+          >
+            <UploadFileIcon sx={{ fontSize: 32, color: 'text.secondary' }} />
+            <Typography variant="body2" color="text.secondary">
+              Drop CSV files here or click to select
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              Vanguard, Schwab, and Schwab RSU formats auto-detected · multiple files OK
+            </Typography>
+          </div>
           <div className={classes.uploadRow}>
-            <UploadButton
-              label="Vanguard"
-              count={countBySource['vanguard'] ?? 0}
-              onFile={addTransactions(parseVanguardCsv, 'vanguard')}
-            />
-            <UploadButton
-              label="Schwab"
-              count={countBySource['schwab'] ?? 0}
-              onFile={addTransactions(parseSchwebCsv, 'schwab')}
-            />
-            <UploadButton
-              label="Schwab RSU"
-              count={countBySource['schwab_equity'] ?? 0}
-              onFile={addTransactions(parseSchwebEquityCsv, 'schwab_equity')}
-            />
-            {transactions.length > 0 && (
-              <Button
+            {countBySource['vanguard'] > 0 && (
+              <Chip
                 size="small"
-                color="error"
-                onClick={() => setTransactions([])}
-              >
+                color="success"
+                variant="outlined"
+                label={`${countBySource['vanguard']} Vanguard`}
+              />
+            )}
+            {countBySource['schwab'] > 0 && (
+              <Chip
+                size="small"
+                color="success"
+                variant="outlined"
+                label={`${countBySource['schwab']} Schwab`}
+              />
+            )}
+            {countBySource['schwab_equity'] > 0 && (
+              <Chip
+                size="small"
+                color="success"
+                variant="outlined"
+                label={`${countBySource['schwab_equity']} Schwab RSU`}
+              />
+            )}
+            {transactions.length > 0 && (
+              <Button size="small" color="error" onClick={() => setTransactions([])}>
                 Clear all
               </Button>
             )}
@@ -391,7 +401,7 @@ export default function BrokeragePage() {
 
               <Typography variant="subtitle2" gutterBottom>Federal</Typography>
               <SummaryRow
-                label={`Standard deduction`}
+                label="Standard deduction"
                 cents={-taxSummary.federalStandardDeductionCents}
               />
               <SummaryRow

--- a/tracker/app/brokerage/components/BrokeragePage.tsx
+++ b/tracker/app/brokerage/components/BrokeragePage.tsx
@@ -274,7 +274,7 @@ export default function BrokeragePage() {
       <MenuBarWithDrawer title="Tax Estimates" />
       <div className={classes.content}>
         <Typography variant="body2" color="text.secondary" gutterBottom>
-          2025 Federal + California estimate · Married Filing Jointly · All figures approximate
+          2026 Federal + California estimate · Married Filing Jointly · All figures approximate
         </Typography>
 
         {/* ── Import ── */}

--- a/tracker/app/brokerage/components/BrokeragePage.tsx
+++ b/tracker/app/brokerage/components/BrokeragePage.tsx
@@ -16,6 +16,7 @@ import { Theme } from '@mui/material/styles';
 import * as React from 'react';
 import MenuBarWithDrawer from '../../main/components/MenuBarWithDrawer';
 import {
+  IBracketInfo,
   IBrokerageTransaction,
   IQualifiedConfig,
   ITaxSummary,
@@ -116,6 +117,14 @@ const useStyles = makeStyles()((_theme: Theme) => ({
   qualifiedField: {
     width: '120px',
   },
+  bracketRoom: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: '2px 0 4px 16px',
+    color: '#666',
+    fontSize: '0.8rem',
+    fontStyle: 'italic',
+  },
   emptyState: {
     color: '#999',
     fontStyle: 'italic',
@@ -192,6 +201,24 @@ function SummaryTotal({ label, cents }: { label: string; cents: number }) {
     <div className={classes.summaryTotal}>
       <Typography variant="body1">{label}</Typography>
       <Typography variant="body1">{fmt(cents)}</Typography>
+    </div>
+  );
+}
+
+function BracketRoom({ info, label }: { info: IBracketInfo; label: string }) {
+  const { classes } = useStyles();
+  const pct = (r: number) => `${(r * 100).toFixed(0)}%`;
+  if (info.roomCents === null || info.nextRate === null) {
+    return (
+      <div className={classes.bracketRoom}>
+        <span>{label}: top bracket ({pct(info.currentRate)})</span>
+      </div>
+    );
+  }
+  return (
+    <div className={classes.bracketRoom}>
+      <span>{label}: {pct(info.currentRate)} bracket</span>
+      <span>{fmt(info.roomCents)} until {pct(info.nextRate)}</span>
     </div>
   );
 }
@@ -409,11 +436,13 @@ export default function BrokeragePage() {
                 cents={taxSummary.federalOrdinaryTaxCents}
                 indent
               />
+              <BracketRoom info={taxSummary.federalOrdinaryBracket} label="Ordinary" />
               <SummaryRow
                 label="LTCG / qualified dividend tax"
                 cents={taxSummary.federalLtcgTaxCents}
                 indent
               />
+              <BracketRoom info={taxSummary.federalLtcgBracket} label="LTCG" />
               {taxSummary.federalNiitCents > 0 && (
                 <SummaryRow
                   label="NIIT (3.8%)"

--- a/tracker/app/brokerage/components/BrokeragePage.tsx
+++ b/tracker/app/brokerage/components/BrokeragePage.tsx
@@ -137,14 +137,16 @@ function categoryLabel(cat: IBrokerageTransaction['category']): string {
     case 'interest': return 'Interest';
     case 'ltcg':     return 'LT Gain';
     case 'stcg':     return 'ST Gain';
+    default:         return cat;
   }
 }
 
 function sourceLabel(src: IBrokerageTransaction['source']): string {
   switch (src) {
-    case 'vanguard':     return 'Vanguard';
-    case 'schwab':       return 'Schwab';
+    case 'vanguard':      return 'Vanguard';
+    case 'schwab':        return 'Schwab';
     case 'schwab_equity': return 'Schwab RSU';
+    default:              return src;
   }
 }
 
@@ -162,7 +164,7 @@ function UploadButton({ label, count, onFile }: IUploadButtonProps) {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (!file) return;
+    if (!file) {return;}
     const reader = new FileReader();
     reader.onload = ev => onFile(ev.target?.result as string ?? '');
     reader.readAsText(file);
@@ -247,13 +249,13 @@ export default function BrokeragePage() {
   const dividendSymbols = React.useMemo(() => {
     const syms = new Set<string>();
     for (const t of transactions) {
-      if (t.category === 'dividend' && t.symbol) syms.add(t.symbol);
+      if (t.category === 'dividend' && t.symbol) {syms.add(t.symbol);}
     }
     return Array.from(syms).sort();
   }, [transactions]);
 
   const taxSummary: ITaxSummary | null = React.useMemo(() => {
-    if (transactions.length === 0) return null;
+    if (transactions.length === 0) {return null;}
     return calculateTax(transactions, qualifiedConfig);
   }, [transactions, qualifiedConfig]);
 
@@ -270,7 +272,7 @@ export default function BrokeragePage() {
 
   const handleQualifiedChange = (symbol: string, value: string) => {
     const pct = parseFloat(value);
-    if (isNaN(pct)) return;
+    if (isNaN(pct)) {return;}
     setQualifiedConfig(prev => ({ ...prev, [symbol]: Math.min(1, Math.max(0, pct / 100)) }));
   };
 

--- a/tracker/app/brokerage/components/BrokeragePage.tsx
+++ b/tracker/app/brokerage/components/BrokeragePage.tsx
@@ -27,7 +27,7 @@ import {
   parseSchwebEquityCsv,
 } from '../csvParser';
 import { calculateTax } from '../taxCalculator';
-import QUALIFIED_DIVIDEND_LOOKUP from '../qualifiedDividendLookup';
+import qualifiedDividendLookup from '../qualifiedDividendLookup';
 
 // ── Styles ────────────────────────────────────────────────────────────────────
 
@@ -277,8 +277,8 @@ export default function BrokeragePage() {
     setQualifiedConfig(prev => {
       const updates: IQualifiedConfig = {};
       for (const sym of newDividendSymbols) {
-        if (!(sym in prev) && sym in QUALIFIED_DIVIDEND_LOOKUP) {
-          updates[sym] = QUALIFIED_DIVIDEND_LOOKUP[sym];
+        if (!(sym in prev) && sym in qualifiedDividendLookup) {
+          updates[sym] = qualifiedDividendLookup[sym];
         }
       }
       return Object.keys(updates).length > 0 ? { ...prev, ...updates } : prev;

--- a/tracker/app/brokerage/csvParser.ts
+++ b/tracker/app/brokerage/csvParser.ts
@@ -1,6 +1,19 @@
 import { parseCsv } from '../transactions/amazonImportUtils';
 import { BrokerageSource, IBrokerageTransaction, IncomeCategory } from './model';
 
+// Sniff the CSV format from its content and dispatch to the right parser.
+// BOM stripping is left to each sub-parser; includes() works fine on raw text.
+export function detectAndParseCsv(text: string): IBrokerageTransaction[] {
+  if (text.includes('Account Number,Trade Date')) {
+    return parseVanguardCsv(text);
+  }
+  const firstLine = text.split('\n')[0];
+  if (firstLine.includes('RealizedGainLoss') || firstLine.includes('FeesAndCommissions')) {
+    return parseSchwebEquityCsv(text);
+  }
+  return parseSchwebCsv(text);
+}
+
 function toYMD(s: string): string {
   s = s.trim();
   // M/D/YYYY or MM/DD/YYYY → YYYY-MM-DD

--- a/tracker/app/brokerage/csvParser.ts
+++ b/tracker/app/brokerage/csvParser.ts
@@ -5,8 +5,8 @@ function toYMD(s: string): string {
   s = s.trim();
   // M/D/YYYY or MM/DD/YYYY → YYYY-MM-DD
   const m = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
-  if (m) return `${m[3]}-${m[1].padStart(2, '0')}-${m[2].padStart(2, '0')}`;
-  if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return s;
+  if (m) {return `${m[3]}-${m[1].padStart(2, '0')}-${m[2].padStart(2, '0')}`;}
+  if (/^\d{4}-\d{2}-\d{2}$/.test(s)) {return s;}
   return s;
 }
 
@@ -15,11 +15,11 @@ function isValidDate(s: string): boolean {
 }
 
 function parseDollars(s: string): number {
-  if (!s) return 0;
+  if (!s) {return 0;}
   const trimmed = s.trim();
   const neg = trimmed.startsWith('(') || trimmed.startsWith('-');
   const val = parseFloat(trimmed.replace(/[$,()]/g, '').replace(/^-/, ''));
-  if (isNaN(val)) return 0;
+  if (isNaN(val)) {return 0;}
   return neg ? -Math.round(val * 100) : Math.round(val * 100);
 }
 
@@ -44,14 +44,14 @@ function makeTransaction(
 // records the taxable income; Reinvestment is just the share purchase.
 export function parseVanguardCsv(text: string): IBrokerageTransaction[] {
   const lines = text
-    .replace(/^﻿/, '')
+    .replace(/^\uFEFF/, '')
     .split('\n')
     .map(l => l.replace(/\r$/, ''));
 
   const txHeaderIdx = lines.findIndex(l =>
     l.startsWith('Account Number,Trade Date'),
   );
-  if (txHeaderIdx === -1) return [];
+  if (txHeaderIdx === -1) {return [];}
 
   const txSection = lines.slice(txHeaderIdx).filter(Boolean).join('\n');
   const rows = parseCsv(txSection);
@@ -64,7 +64,7 @@ export function parseVanguardCsv(text: string): IBrokerageTransaction[] {
     const date = toYMD(row['Trade Date'] || '');
     const amountCents = parseDollars(row['Net Amount'] || '');
 
-    if (!isValidDate(date) || amountCents === 0) continue;
+    if (!isValidDate(date) || amountCents === 0) {continue;}
 
     let category: IncomeCategory;
     if (type === 'Dividend') {
@@ -89,21 +89,21 @@ export function parseVanguardCsv(text: string): IBrokerageTransaction[] {
 // Schwab simple brokerage CSV.
 // Sells are skipped — no cost basis in this export format.
 export function parseSchwebCsv(text: string): IBrokerageTransaction[] {
-  const rows = parseCsv(text.replace(/^﻿/, ''));
+  const rows = parseCsv(text.replace(/^\uFEFF/, ''));
   const result: IBrokerageTransaction[] = [];
 
   for (const row of rows) {
     const dateStr = (row['Date'] || '').trim();
-    if (!dateStr) continue;
+    if (!dateStr) {continue;}
     const date = toYMD(dateStr);
-    if (!isValidDate(date)) continue; // skip totals/summary rows
+    if (!isValidDate(date)) {continue;} // skip totals/summary rows
 
     const action = (row['Action'] || '').trim().toLowerCase();
     const symbol = (row['Symbol'] || '').trim();
     const description = (row['Description'] || '').trim();
     const amountCents = parseDollars(row['Amount'] || '');
 
-    if (amountCents === 0) continue;
+    if (amountCents === 0) {continue;}
 
     let category: IncomeCategory;
     if (
@@ -130,21 +130,21 @@ export function parseSchwebCsv(text: string): IBrokerageTransaction[] {
 // The vest-day ordinary income is already handled via W-2 — only the
 // subsequent capital gain/loss is recorded here.
 export function parseSchwebEquityCsv(text: string): IBrokerageTransaction[] {
-  const rows = parseCsv(text.replace(/^﻿/, ''));
+  const rows = parseCsv(text.replace(/^\uFEFF/, ''));
   const result: IBrokerageTransaction[] = [];
 
   for (const row of rows) {
     const gainStr = (row['RealizedGainLoss'] || '').trim();
-    if (!gainStr || gainStr === 'N/A' || gainStr === '--') continue;
+    if (!gainStr || gainStr === 'N/A' || gainStr === '--') {continue;}
 
     const dateStr = (row['Date'] || '').trim();
     const date = toYMD(dateStr);
-    if (!isValidDate(date)) continue;
+    if (!isValidDate(date)) {continue;}
 
     const symbol = (row['Symbol'] || '').trim();
     const description = (row['Description'] || '').trim();
     const gainCents = parseDollars(gainStr);
-    if (gainCents === 0) continue;
+    if (gainCents === 0) {continue;}
 
     const holdingPeriod = (row['HoldingPeriod'] || '').trim().toLowerCase();
     const category: IncomeCategory = holdingPeriod.includes('long') ? 'ltcg' : 'stcg';

--- a/tracker/app/brokerage/csvParser.ts
+++ b/tracker/app/brokerage/csvParser.ts
@@ -88,6 +88,8 @@ export function parseVanguardCsv(text: string): IBrokerageTransaction[] {
 
 // Schwab simple brokerage CSV.
 // Sells are skipped — no cost basis in this export format.
+// Action names for dividends vary ("Qual Div Reinvest", "Cash Div", etc.) so
+// we match any action containing "div" (case-insensitive).
 export function parseSchwebCsv(text: string): IBrokerageTransaction[] {
   const rows = parseCsv(text.replace(/^\uFEFF/, ''));
   const result: IBrokerageTransaction[] = [];
@@ -106,16 +108,12 @@ export function parseSchwebCsv(text: string): IBrokerageTransaction[] {
     if (amountCents === 0) {continue;}
 
     let category: IncomeCategory;
-    if (
-      action === 'div' ||
-      action === 'cash div' ||
-      action.includes('dividend')
-    ) {
+    if (action.includes('div')) {
       category = 'dividend';
     } else if (action.includes('interest')) {
       category = 'interest';
     } else {
-      // Buy, Sell (no basis), Wire, Journal, etc.
+      // Buy, Sell (no basis), Wire, Journal, Reinvest Shares, etc.
       continue;
     }
 
@@ -125,31 +123,48 @@ export function parseSchwebCsv(text: string): IBrokerageTransaction[] {
   return result;
 }
 
-// Schwab equity awards CSV (RSU sales).
-// Each row with a non-empty RealizedGainLoss is a capital gain/loss event.
-// The vest-day ordinary income is already handled via W-2 — only the
-// subsequent capital gain/loss is recorded here.
+// Schwab equity awards CSV (RSU sales + dividends on held shares).
+//
+// The export uses a parent/child row structure for sales:
+//   Parent: Action="Sale", has Date/Symbol, but RealizedGainLoss is empty.
+//   Child:  Type="RS",     has RealizedGainLoss/HoldingPeriod, but Date/Symbol are empty.
+// We track the parent sale row's date and symbol, then apply them to each RS child.
+// Dividend rows (on held RSU shares) are also parsed.
+// The vest-day ordinary income is already on the W-2 — only subsequent cap gains are recorded.
 export function parseSchwebEquityCsv(text: string): IBrokerageTransaction[] {
   const rows = parseCsv(text.replace(/^\uFEFF/, ''));
   const result: IBrokerageTransaction[] = [];
 
+  let saleDate = '';
+  let saleSymbol = '';
+  let saleDescription = '';
+
   for (const row of rows) {
-    const gainStr = (row['RealizedGainLoss'] || '').trim();
-    if (!gainStr || gainStr === 'N/A' || gainStr === '--') {continue;}
+    const action = (row['Action'] || '').trim();
+    const type = (row['Type'] || '').trim();
 
-    const dateStr = (row['Date'] || '').trim();
-    const date = toYMD(dateStr);
-    if (!isValidDate(date)) {continue;}
-
-    const symbol = (row['Symbol'] || '').trim();
-    const description = (row['Description'] || '').trim();
-    const gainCents = parseDollars(gainStr);
-    if (gainCents === 0) {continue;}
-
-    const holdingPeriod = (row['HoldingPeriod'] || '').trim().toLowerCase();
-    const category: IncomeCategory = holdingPeriod.includes('long') ? 'ltcg' : 'stcg';
-
-    result.push(makeTransaction(date, 'schwab_equity', symbol, description, category, gainCents));
+    if (action === 'Sale') {
+      saleDate = toYMD((row['Date'] || '').trim());
+      saleSymbol = (row['Symbol'] || '').trim();
+      saleDescription = (row['Description'] || '').trim();
+    } else if (type === 'RS') {
+      const gainStr = (row['RealizedGainLoss'] || '').trim();
+      if (!gainStr || gainStr === 'N/A' || gainStr === '--') {continue;}
+      if (!isValidDate(saleDate)) {continue;}
+      const gainCents = parseDollars(gainStr);
+      if (gainCents === 0) {continue;}
+      const holdingPeriod = (row['HoldingPeriod'] || '').trim().toLowerCase();
+      const category: IncomeCategory = holdingPeriod.includes('long') ? 'ltcg' : 'stcg';
+      result.push(makeTransaction(saleDate, 'schwab_equity', saleSymbol, saleDescription, category, gainCents));
+    } else if (action === 'Dividend') {
+      const date = toYMD((row['Date'] || '').trim());
+      if (!isValidDate(date)) {continue;}
+      const amountCents = parseDollars(row['Amount'] || '');
+      if (amountCents === 0) {continue;}
+      const symbol = (row['Symbol'] || '').trim();
+      const description = (row['Description'] || '').trim();
+      result.push(makeTransaction(date, 'schwab_equity', symbol, description, 'dividend', amountCents));
+    }
   }
 
   return result;

--- a/tracker/app/brokerage/csvParser.ts
+++ b/tracker/app/brokerage/csvParser.ts
@@ -1,0 +1,156 @@
+import { parseCsv } from '../transactions/amazonImportUtils';
+import { BrokerageSource, IBrokerageTransaction, IncomeCategory } from './model';
+
+function toYMD(s: string): string {
+  s = s.trim();
+  // M/D/YYYY or MM/DD/YYYY → YYYY-MM-DD
+  const m = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (m) return `${m[3]}-${m[1].padStart(2, '0')}-${m[2].padStart(2, '0')}`;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return s;
+  return s;
+}
+
+function isValidDate(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
+
+function parseDollars(s: string): number {
+  if (!s) return 0;
+  const trimmed = s.trim();
+  const neg = trimmed.startsWith('(') || trimmed.startsWith('-');
+  const val = parseFloat(trimmed.replace(/[$,()]/g, '').replace(/^-/, ''));
+  if (isNaN(val)) return 0;
+  return neg ? -Math.round(val * 100) : Math.round(val * 100);
+}
+
+function makeTransaction(
+  date: string,
+  source: BrokerageSource,
+  symbol: string,
+  description: string,
+  category: IncomeCategory,
+  amountCents: number,
+): IBrokerageTransaction {
+  return { date, source, symbol, description, category, amountCents };
+}
+
+// Vanguard CSV has two sections in one file:
+//   Section 1: holdings  (header: "Account Number,Investment Name,Symbol,...")
+//   Section 2: transactions (header: "Account Number,Trade Date,...")
+// We detect the transactions section by its header and parse only that.
+//
+// Vanguard sells are skipped — cost basis is not included in the export.
+// Reinvestment rows are skipped — the corresponding Dividend row already
+// records the taxable income; Reinvestment is just the share purchase.
+export function parseVanguardCsv(text: string): IBrokerageTransaction[] {
+  const lines = text
+    .replace(/^﻿/, '')
+    .split('\n')
+    .map(l => l.replace(/\r$/, ''));
+
+  const txHeaderIdx = lines.findIndex(l =>
+    l.startsWith('Account Number,Trade Date'),
+  );
+  if (txHeaderIdx === -1) return [];
+
+  const txSection = lines.slice(txHeaderIdx).filter(Boolean).join('\n');
+  const rows = parseCsv(txSection);
+  const result: IBrokerageTransaction[] = [];
+
+  for (const row of rows) {
+    const type = (row['Transaction Type'] || '').trim();
+    const symbol = (row['Symbol'] || '').trim();
+    const description = (row['Investment Name'] || '').trim();
+    const date = toYMD(row['Trade Date'] || '');
+    const amountCents = parseDollars(row['Net Amount'] || '');
+
+    if (!isValidDate(date) || amountCents === 0) continue;
+
+    let category: IncomeCategory;
+    if (type === 'Dividend') {
+      category = 'dividend';
+    } else if (type === 'Interest') {
+      category = 'interest';
+    } else if (type === 'Sell') {
+      // Cost basis not available in transaction CSV — skipped.
+      // Capital gains from Vanguard fund sales must come from the 1099-B.
+      continue;
+    } else {
+      // Buy, Reinvestment, Sweep in/out, Withdrawal, etc. — not taxable events
+      continue;
+    }
+
+    result.push(makeTransaction(date, 'vanguard', symbol, description, category, amountCents));
+  }
+
+  return result;
+}
+
+// Schwab simple brokerage CSV.
+// Sells are skipped — no cost basis in this export format.
+export function parseSchwebCsv(text: string): IBrokerageTransaction[] {
+  const rows = parseCsv(text.replace(/^﻿/, ''));
+  const result: IBrokerageTransaction[] = [];
+
+  for (const row of rows) {
+    const dateStr = (row['Date'] || '').trim();
+    if (!dateStr) continue;
+    const date = toYMD(dateStr);
+    if (!isValidDate(date)) continue; // skip totals/summary rows
+
+    const action = (row['Action'] || '').trim().toLowerCase();
+    const symbol = (row['Symbol'] || '').trim();
+    const description = (row['Description'] || '').trim();
+    const amountCents = parseDollars(row['Amount'] || '');
+
+    if (amountCents === 0) continue;
+
+    let category: IncomeCategory;
+    if (
+      action === 'div' ||
+      action === 'cash div' ||
+      action.includes('dividend')
+    ) {
+      category = 'dividend';
+    } else if (action.includes('interest')) {
+      category = 'interest';
+    } else {
+      // Buy, Sell (no basis), Wire, Journal, etc.
+      continue;
+    }
+
+    result.push(makeTransaction(date, 'schwab', symbol, description, category, amountCents));
+  }
+
+  return result;
+}
+
+// Schwab equity awards CSV (RSU sales).
+// Each row with a non-empty RealizedGainLoss is a capital gain/loss event.
+// The vest-day ordinary income is already handled via W-2 — only the
+// subsequent capital gain/loss is recorded here.
+export function parseSchwebEquityCsv(text: string): IBrokerageTransaction[] {
+  const rows = parseCsv(text.replace(/^﻿/, ''));
+  const result: IBrokerageTransaction[] = [];
+
+  for (const row of rows) {
+    const gainStr = (row['RealizedGainLoss'] || '').trim();
+    if (!gainStr || gainStr === 'N/A' || gainStr === '--') continue;
+
+    const dateStr = (row['Date'] || '').trim();
+    const date = toYMD(dateStr);
+    if (!isValidDate(date)) continue;
+
+    const symbol = (row['Symbol'] || '').trim();
+    const description = (row['Description'] || '').trim();
+    const gainCents = parseDollars(gainStr);
+    if (gainCents === 0) continue;
+
+    const holdingPeriod = (row['HoldingPeriod'] || '').trim().toLowerCase();
+    const category: IncomeCategory = holdingPeriod.includes('long') ? 'ltcg' : 'stcg';
+
+    result.push(makeTransaction(date, 'schwab_equity', symbol, description, category, gainCents));
+  }
+
+  return result;
+}

--- a/tracker/app/brokerage/model.ts
+++ b/tracker/app/brokerage/model.ts
@@ -1,0 +1,42 @@
+export type BrokerageSource = 'vanguard' | 'schwab' | 'schwab_equity';
+
+export type IncomeCategory =
+  | 'dividend'  // qualified fraction determined by qualifiedConfig
+  | 'interest'  // always ordinary income
+  | 'ltcg'      // long-term capital gain (or loss)
+  | 'stcg';     // short-term capital gain (or loss)
+
+export interface IBrokerageTransaction {
+  date: string;         // YYYY-MM-DD
+  source: BrokerageSource;
+  symbol: string;
+  description: string;
+  category: IncomeCategory;
+  amountCents: number;  // positive = income/gain, negative = loss
+}
+
+// symbol → fraction of dividends that are qualified (0.0 – 1.0)
+// Sourced from prior-year 1099-DIV. Persisted in localStorage.
+export type IQualifiedConfig = Record<string, number>;
+
+export interface ITaxSummary {
+  // Income buckets (before deductions)
+  qualifiedDividendsCents: number;
+  ordinaryDividendsCents: number;
+  interestCents: number;
+  ltcgCents: number;
+  stcgCents: number;
+  // Federal
+  federalStandardDeductionCents: number;
+  federalTaxableOrdinaryCents: number;
+  federalOrdinaryTaxCents: number;
+  federalLtcgTaxCents: number;
+  federalNiitCents: number;
+  federalTotalCents: number;
+  // California
+  caStandardDeductionCents: number;
+  caTaxableIncomeCents: number;
+  caTaxCents: number;
+  // Grand total
+  totalTaxCents: number;
+}

--- a/tracker/app/brokerage/model.ts
+++ b/tracker/app/brokerage/model.ts
@@ -19,6 +19,12 @@ export interface IBrokerageTransaction {
 // Sourced from prior-year 1099-DIV. Persisted in localStorage.
 export type IQualifiedConfig = Record<string, number>;
 
+export interface IBracketInfo {
+  currentRate: number;
+  nextRate: number | null;   // null if already in the top bracket
+  roomCents: number | null;  // how much more income before hitting the next bracket
+}
+
 export interface ITaxSummary {
   // Income buckets (before deductions)
   qualifiedDividendsCents: number;
@@ -37,6 +43,9 @@ export interface ITaxSummary {
   caStandardDeductionCents: number;
   caTaxableIncomeCents: number;
   caTaxCents: number;
+  // Bracket headroom (federal only — used for planning)
+  federalOrdinaryBracket: IBracketInfo;
+  federalLtcgBracket: IBracketInfo;
   // Grand total
   totalTaxCents: number;
 }

--- a/tracker/app/brokerage/qualifiedDividendLookup.ts
+++ b/tracker/app/brokerage/qualifiedDividendLookup.ts
@@ -6,7 +6,7 @@
 // Domestic equity ETFs/funds → near 100% (all US corp dividends).
 // International equity → partial, depending on tax treaties (~60-65%).
 // Individual US stocks → 100% (assuming >60 day holding period met).
-const QUALIFIED_DIVIDEND_LOOKUP: Record<string, number> = {
+const qualifiedDividendLookup: Record<string, number> = {
   // Individual US stocks
   AAPL:  1.00,
   GOOG:  1.00,
@@ -30,4 +30,4 @@ const QUALIFIED_DIVIDEND_LOOKUP: Record<string, number> = {
   VXUS:  0.63, // Vanguard Total International Stock ETF
 };
 
-export default QUALIFIED_DIVIDEND_LOOKUP;
+export default qualifiedDividendLookup;

--- a/tracker/app/brokerage/qualifiedDividendLookup.ts
+++ b/tracker/app/brokerage/qualifiedDividendLookup.ts
@@ -1,0 +1,33 @@
+// Estimated qualified dividend fractions by ticker, based on prior-year fund
+// distributions. These are stable year-over-year for broad index funds.
+// Sources: Vanguard tax center, Schwab fund documents, IRS qualified dividend rules.
+//
+// Bond funds and money markets pay interest, not dividends → 0%.
+// Domestic equity ETFs/funds → near 100% (all US corp dividends).
+// International equity → partial, depending on tax treaties (~60-65%).
+// Individual US stocks → 100% (assuming >60 day holding period met).
+const QUALIFIED_DIVIDEND_LOOKUP: Record<string, number> = {
+  // Individual US stocks
+  AAPL:  1.00,
+  GOOG:  1.00,
+  GOOGL: 1.00,
+
+  // Schwab funds
+  SWPPX: 1.00, // Schwab S&P 500 Index — all domestic large cap
+
+  // Vanguard bond / money market — interest income, never qualified
+  BND:   0.00, // Vanguard Total Bond Market ETF
+  VBTLX: 0.00, // Vanguard Total Bond Market Index Admiral
+  VMFXX: 0.00, // Vanguard Federal Money Market Fund
+
+  // Vanguard domestic equity — highly qualified
+  VLGSX: 0.99, // Vanguard Large-Cap Index Admiral
+  VOO:   1.00, // Vanguard S&P 500 ETF
+  VTI:   0.85, // Vanguard Total Stock Market ETF (includes small cap, slightly lower)
+
+  // Vanguard international equity — partially qualified via tax treaties
+  VEUSX: 0.65, // Vanguard European Stock Index Admiral
+  VXUS:  0.63, // Vanguard Total International Stock ETF
+};
+
+export default QUALIFIED_DIVIDEND_LOOKUP;

--- a/tracker/app/brokerage/taxCalculator.ts
+++ b/tracker/app/brokerage/taxCalculator.ts
@@ -1,48 +1,50 @@
 import { IBrokerageTransaction, IQualifiedConfig, ITaxSummary } from './model';
 
-// ── 2025 Tax Year Constants (Married Filing Jointly) ──────────────────────────
+// ── 2026 Tax Year Constants (Married Filing Jointly) ──────────────────────────
 
 const c = (dollars: number) => Math.round(dollars * 100); // dollars → cents
 
-// Federal ordinary income brackets (MFJ 2025)
+// Federal ordinary income brackets (MFJ 2026) — IRS Rev. Proc. 2025-xx
 const FED_ORDINARY_BRACKETS = [
-  { min: c(0),       max: c(23_850),   rate: 0.10 },
-  { min: c(23_850),  max: c(96_950),   rate: 0.12 },
-  { min: c(96_950),  max: c(206_700),  rate: 0.22 },
-  { min: c(206_700), max: c(394_600),  rate: 0.24 },
-  { min: c(394_600), max: c(501_050),  rate: 0.32 },
-  { min: c(501_050), max: c(751_600),  rate: 0.35 },
-  { min: c(751_600), max: Infinity,    rate: 0.37 },
+  { min: c(0),        max: c(24_800),   rate: 0.10 },
+  { min: c(24_800),   max: c(100_800),  rate: 0.12 },
+  { min: c(100_800),  max: c(211_400),  rate: 0.22 },
+  { min: c(211_400),  max: c(403_550),  rate: 0.24 },
+  { min: c(403_550),  max: c(512_450),  rate: 0.32 },
+  { min: c(512_450),  max: c(768_700),  rate: 0.35 },
+  { min: c(768_700),  max: Infinity,    rate: 0.37 },
 ];
 
-// Federal LTCG / qualified-dividend brackets (MFJ 2025)
+// Federal LTCG / qualified-dividend brackets (MFJ 2026)
 const FED_LTCG_BRACKETS = [
-  { min: c(0),        max: c(96_700),   rate: 0.00 },
-  { min: c(96_700),   max: c(583_750),  rate: 0.15 },
-  { min: c(583_750),  max: Infinity,    rate: 0.20 },
+  { min: c(0),        max: c(98_900),   rate: 0.00 },
+  { min: c(98_900),   max: c(613_700),  rate: 0.15 },
+  { min: c(613_700),  max: Infinity,    rate: 0.20 },
 ];
 
-const FED_STANDARD_DEDUCTION = c(30_000);
+const FED_STANDARD_DEDUCTION = c(32_200);
 
 // Net Investment Income Tax: 3.8% on NII above $250k (MFJ, not inflation-adjusted)
 const NIIT_THRESHOLD = c(250_000);
 const NIIT_RATE = 0.038;
 
-// California ordinary income brackets (MFJ 2025, approximate — CA adjusts annually)
-// Top bracket includes the 1% Mental Health Services Tax surtax above $1M.
+// California ordinary income brackets (MFJ 2025 — 2026 brackets not yet published by FTB)
+// Above $1M the 1% Mental Health Services Tax surcharge applies, so the effective rates
+// for the top two segments are 12.3% ($1M–$1,485,906) and 13.3% (above $1,485,906).
 const CA_BRACKETS = [
-  { min: c(0),          max: c(20_824),    rate: 0.010 },
-  { min: c(20_824),     max: c(49_368),    rate: 0.020 },
-  { min: c(49_368),     max: c(77_918),    rate: 0.040 },
-  { min: c(77_918),     max: c(108_162),   rate: 0.060 },
-  { min: c(108_162),    max: c(136_700),   rate: 0.080 },
-  { min: c(136_700),    max: c(698_274),   rate: 0.093 },
-  { min: c(698_274),    max: c(837_922),   rate: 0.103 },
-  { min: c(837_922),    max: c(1_000_000), rate: 0.113 },
-  { min: c(1_000_000),  max: Infinity,     rate: 0.133 },
+  { min: c(0),           max: c(22_158),    rate: 0.010 },
+  { min: c(22_158),      max: c(52_528),    rate: 0.020 },
+  { min: c(52_528),      max: c(82_904),    rate: 0.040 },
+  { min: c(82_904),      max: c(115_084),   rate: 0.060 },
+  { min: c(115_084),     max: c(145_448),   rate: 0.080 },
+  { min: c(145_448),     max: c(742_958),   rate: 0.093 },
+  { min: c(742_958),     max: c(891_542),   rate: 0.103 },
+  { min: c(891_542),     max: c(1_000_000), rate: 0.113 },
+  { min: c(1_000_000),   max: c(1_485_906), rate: 0.123 },
+  { min: c(1_485_906),   max: Infinity,     rate: 0.133 },
 ];
 
-const CA_STANDARD_DEDUCTION = c(10_726);
+const CA_STANDARD_DEDUCTION = c(11_412);
 
 // ── Bracket helpers ───────────────────────────────────────────────────────────
 

--- a/tracker/app/brokerage/taxCalculator.ts
+++ b/tracker/app/brokerage/taxCalculator.ts
@@ -53,7 +53,7 @@ function applyBrackets(amountCents: number, brackets: IBracket[]): number {
   let tax = 0;
   let remaining = Math.max(0, amountCents);
   for (const b of brackets) {
-    if (remaining <= 0) break;
+    if (remaining <= 0) {break;}
     const room = Math.min(remaining, b.max - b.min);
     tax += room * b.rate;
     remaining -= room;
@@ -71,7 +71,7 @@ function applyLtcgBrackets(
   let tax = 0;
   let remaining = Math.max(0, ltcgCents);
   for (const b of brackets) {
-    if (remaining <= 0) break;
+    if (remaining <= 0) {break;}
     // Room in this bracket after ordinary income has already filled it.
     const roomStart = Math.max(b.min, stackedOrdinaryCents);
     const room = Math.max(0, b.max - roomStart);
@@ -107,6 +107,8 @@ export function calculateTax(
         break;
       case 'stcg':
         stcgCents += t.amountCents;
+        break;
+      default:
         break;
     }
   }

--- a/tracker/app/brokerage/taxCalculator.ts
+++ b/tracker/app/brokerage/taxCalculator.ts
@@ -1,0 +1,168 @@
+import { IBrokerageTransaction, IQualifiedConfig, ITaxSummary } from './model';
+
+// ── 2025 Tax Year Constants (Married Filing Jointly) ──────────────────────────
+
+const c = (dollars: number) => Math.round(dollars * 100); // dollars → cents
+
+// Federal ordinary income brackets (MFJ 2025)
+const FED_ORDINARY_BRACKETS = [
+  { min: c(0),       max: c(23_850),   rate: 0.10 },
+  { min: c(23_850),  max: c(96_950),   rate: 0.12 },
+  { min: c(96_950),  max: c(206_700),  rate: 0.22 },
+  { min: c(206_700), max: c(394_600),  rate: 0.24 },
+  { min: c(394_600), max: c(501_050),  rate: 0.32 },
+  { min: c(501_050), max: c(751_600),  rate: 0.35 },
+  { min: c(751_600), max: Infinity,    rate: 0.37 },
+];
+
+// Federal LTCG / qualified-dividend brackets (MFJ 2025)
+const FED_LTCG_BRACKETS = [
+  { min: c(0),        max: c(96_700),   rate: 0.00 },
+  { min: c(96_700),   max: c(583_750),  rate: 0.15 },
+  { min: c(583_750),  max: Infinity,    rate: 0.20 },
+];
+
+const FED_STANDARD_DEDUCTION = c(30_000);
+
+// Net Investment Income Tax: 3.8% on NII above $250k (MFJ, not inflation-adjusted)
+const NIIT_THRESHOLD = c(250_000);
+const NIIT_RATE = 0.038;
+
+// California ordinary income brackets (MFJ 2025, approximate — CA adjusts annually)
+// Top bracket includes the 1% Mental Health Services Tax surtax above $1M.
+const CA_BRACKETS = [
+  { min: c(0),          max: c(20_824),    rate: 0.010 },
+  { min: c(20_824),     max: c(49_368),    rate: 0.020 },
+  { min: c(49_368),     max: c(77_918),    rate: 0.040 },
+  { min: c(77_918),     max: c(108_162),   rate: 0.060 },
+  { min: c(108_162),    max: c(136_700),   rate: 0.080 },
+  { min: c(136_700),    max: c(698_274),   rate: 0.093 },
+  { min: c(698_274),    max: c(837_922),   rate: 0.103 },
+  { min: c(837_922),    max: c(1_000_000), rate: 0.113 },
+  { min: c(1_000_000),  max: Infinity,     rate: 0.133 },
+];
+
+const CA_STANDARD_DEDUCTION = c(10_726);
+
+// ── Bracket helpers ───────────────────────────────────────────────────────────
+
+interface IBracket { min: number; max: number; rate: number; }
+
+// Progressive ordinary income tax.
+function applyBrackets(amountCents: number, brackets: IBracket[]): number {
+  let tax = 0;
+  let remaining = Math.max(0, amountCents);
+  for (const b of brackets) {
+    if (remaining <= 0) break;
+    const room = Math.min(remaining, b.max - b.min);
+    tax += room * b.rate;
+    remaining -= room;
+  }
+  return Math.round(tax);
+}
+
+// LTCG / qualified dividends are taxed at preferential rates but "stack" on
+// top of ordinary taxable income when determining which bracket applies.
+function applyLtcgBrackets(
+  ltcgCents: number,
+  stackedOrdinaryCents: number,
+  brackets: IBracket[],
+): number {
+  let tax = 0;
+  let remaining = Math.max(0, ltcgCents);
+  for (const b of brackets) {
+    if (remaining <= 0) break;
+    // Room in this bracket after ordinary income has already filled it.
+    const roomStart = Math.max(b.min, stackedOrdinaryCents);
+    const room = Math.max(0, b.max - roomStart);
+    const taxed = Math.min(remaining, room);
+    tax += taxed * b.rate;
+    remaining -= taxed;
+  }
+  return Math.round(tax);
+}
+
+// ── Main calculation ──────────────────────────────────────────────────────────
+
+export function calculateTax(
+  transactions: IBrokerageTransaction[],
+  qualifiedConfig: IQualifiedConfig,
+): ITaxSummary {
+  // Aggregate dividends by symbol so we can apply per-symbol qualified fractions.
+  const dividendsBySymbol: Record<string, number> = {};
+  let interestCents = 0;
+  let ltcgCents = 0;
+  let stcgCents = 0;
+
+  for (const t of transactions) {
+    switch (t.category) {
+      case 'dividend':
+        dividendsBySymbol[t.symbol] = (dividendsBySymbol[t.symbol] ?? 0) + t.amountCents;
+        break;
+      case 'interest':
+        interestCents += t.amountCents;
+        break;
+      case 'ltcg':
+        ltcgCents += t.amountCents;
+        break;
+      case 'stcg':
+        stcgCents += t.amountCents;
+        break;
+    }
+  }
+
+  let qualifiedDividendsCents = 0;
+  let ordinaryDividendsCents = 0;
+  for (const [symbol, total] of Object.entries(dividendsBySymbol)) {
+    const qualFrac = Math.min(1, Math.max(0, qualifiedConfig[symbol] ?? 0));
+    qualifiedDividendsCents += Math.round(total * qualFrac);
+    ordinaryDividendsCents += Math.round(total * (1 - qualFrac));
+  }
+
+  // ── Federal ───────────────────────────────────────────────────────────────
+
+  const fedOrdinaryIncomeCents = ordinaryDividendsCents + interestCents + stcgCents;
+  const federalTaxableOrdinaryCents = Math.max(0, fedOrdinaryIncomeCents - FED_STANDARD_DEDUCTION);
+  const federalOrdinaryTaxCents = applyBrackets(federalTaxableOrdinaryCents, FED_ORDINARY_BRACKETS);
+
+  const fedPreferentialCents = qualifiedDividendsCents + ltcgCents;
+  const federalLtcgTaxCents = applyLtcgBrackets(
+    fedPreferentialCents,
+    federalTaxableOrdinaryCents,
+    FED_LTCG_BRACKETS,
+  );
+
+  // NIIT: 3.8% × min(NII, max(0, MAGI − threshold)).
+  // With no W-2 income, NII = MAGI = total investment income.
+  const totalInvestmentIncomeCents = fedOrdinaryIncomeCents + fedPreferentialCents;
+  const niitBaseCents = Math.max(0, totalInvestmentIncomeCents - NIIT_THRESHOLD);
+  const federalNiitCents = Math.round(niitBaseCents * NIIT_RATE);
+
+  const federalTotalCents = federalOrdinaryTaxCents + federalLtcgTaxCents + federalNiitCents;
+
+  // ── California ────────────────────────────────────────────────────────────
+  // CA taxes all investment income at ordinary rates — no preferential LTCG rate.
+
+  const caAllIncomeCents =
+    ordinaryDividendsCents + qualifiedDividendsCents + interestCents + ltcgCents + stcgCents;
+  const caTaxableIncomeCents = Math.max(0, caAllIncomeCents - CA_STANDARD_DEDUCTION);
+  const caTaxCents = applyBrackets(caTaxableIncomeCents, CA_BRACKETS);
+
+  return {
+    qualifiedDividendsCents,
+    ordinaryDividendsCents,
+    interestCents,
+    ltcgCents,
+    stcgCents,
+    federalStandardDeductionCents: FED_STANDARD_DEDUCTION,
+    federalTaxableOrdinaryCents,
+    federalOrdinaryTaxCents,
+    federalLtcgTaxCents,
+    federalNiitCents,
+    federalTotalCents,
+    caStandardDeductionCents: CA_STANDARD_DEDUCTION,
+    caTaxableIncomeCents,
+    caTaxCents,
+    totalTaxCents: federalTotalCents + caTaxCents,
+  };
+}

--- a/tracker/app/brokerage/taxCalculator.ts
+++ b/tracker/app/brokerage/taxCalculator.ts
@@ -1,4 +1,4 @@
-import { IBrokerageTransaction, IQualifiedConfig, ITaxSummary } from './model';
+import { IBracketInfo, IBrokerageTransaction, IQualifiedConfig, ITaxSummary } from './model';
 
 // ── 2026 Tax Year Constants (Married Filing Jointly) ──────────────────────────
 
@@ -49,6 +49,23 @@ const CA_STANDARD_DEDUCTION = c(11_412);
 // ── Bracket helpers ───────────────────────────────────────────────────────────
 
 interface IBracket { min: number; max: number; rate: number; }
+
+// Returns the current bracket rate and how much room is left before the next bracket.
+// For LTCG with stacking, pass the combined (ordinary + LTCG) position as `position`.
+function getBracketInfo(position: number, brackets: IBracket[]): IBracketInfo {
+  for (let i = 0; i < brackets.length; i++) {
+    if (position < brackets[i].max || i === brackets.length - 1) {
+      const next = i < brackets.length - 1 ? brackets[i + 1] : null;
+      return {
+        currentRate: brackets[i].rate,
+        nextRate: next ? next.rate : null,
+        roomCents: next ? Math.max(0, next.min - position) : null,
+      };
+    }
+  }
+  const last = brackets[brackets.length - 1];
+  return { currentRate: last.rate, nextRate: null, roomCents: null };
+}
 
 // Progressive ordinary income tax.
 function applyBrackets(amountCents: number, brackets: IBracket[]): number {
@@ -144,6 +161,13 @@ export function calculateTax(
 
   const federalTotalCents = federalOrdinaryTaxCents + federalLtcgTaxCents + federalNiitCents;
 
+  const federalOrdinaryBracket = getBracketInfo(federalTaxableOrdinaryCents, FED_ORDINARY_BRACKETS);
+  // LTCG stacks on top of ordinary taxable income when finding the applicable bracket.
+  const federalLtcgBracket = getBracketInfo(
+    federalTaxableOrdinaryCents + fedPreferentialCents,
+    FED_LTCG_BRACKETS,
+  );
+
   // ── California ────────────────────────────────────────────────────────────
   // CA taxes all investment income at ordinary rates — no preferential LTCG rate.
 
@@ -164,6 +188,8 @@ export function calculateTax(
     federalLtcgTaxCents,
     federalNiitCents,
     federalTotalCents,
+    federalOrdinaryBracket,
+    federalLtcgBracket,
     caStandardDeductionCents: CA_STANDARD_DEDUCTION,
     caTaxableIncomeCents,
     caTaxCents,

--- a/tracker/app/main/components/App.tsx
+++ b/tracker/app/main/components/App.tsx
@@ -9,6 +9,7 @@ import Login from './Login';
 import Monthly from './Monthly';
 import Categories from './Categories';
 import Report from './Report';
+import BrokeragePage from '../../brokerage/components/BrokeragePage';
 import * as RoutePaths from './RoutePaths';
 
 const globalStyles = {
@@ -70,6 +71,14 @@ const App: React.FC = () => {
           element={
             <AuthRoute>
               <Categories />
+            </AuthRoute>
+          }
+        />
+        <Route
+          path={RoutePaths.BrokeragePage}
+          element={
+            <AuthRoute>
+              <BrokeragePage />
             </AuthRoute>
           }
         />

--- a/tracker/app/main/components/MenuBarWithDrawer.tsx
+++ b/tracker/app/main/components/MenuBarWithDrawer.tsx
@@ -9,6 +9,7 @@ import { Theme } from '@mui/material/styles';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import BarChartIcon from '@mui/icons-material/BarChart';
+import CalculateIcon from '@mui/icons-material/Calculate';
 import CategoryIcon from '@mui/icons-material/Category';
 import EditIcon from '@mui/icons-material/Edit';
 import LabelIcon from '@mui/icons-material/Label';
@@ -202,6 +203,23 @@ class MenuBarWithDrawerInner extends React.Component<
               <ListItemText
                 classes={{ primary: classes.drawerItemText }}
                 primary="Categories"
+              />
+            </ListItemButton>
+            <ListItemButton
+              key="Brokerage"
+              onClick={() => this.handleNavigate(Pages.BrokeragePage)}
+              selected={selectedPage === Pages.BrokeragePage}
+            >
+              <ListItemIcon>
+                <CalculateIcon
+                  color={
+                    selectedPage === Pages.BrokeragePage ? 'primary' : 'inherit'
+                  }
+                />
+              </ListItemIcon>
+              <ListItemText
+                classes={{ primary: classes.drawerItemText }}
+                primary="Tax Estimates"
               />
             </ListItemButton>
           </List>

--- a/tracker/app/main/components/RoutePaths.ts
+++ b/tracker/app/main/components/RoutePaths.ts
@@ -5,3 +5,4 @@ export const MonthlyPage = '/monthly';
 export const EditorPage = '/editor';
 export const ReportPage = '/report';
 export const CategoriesPage = '/categories';
+export const BrokeragePage = '/brokerage';


### PR DESCRIPTION
## Summary

New **Tax Estimates** page (`/brokerage`) accessible from the nav drawer. Drop or select CSV exports from Vanguard and Schwab to get a 2026 MFJ Federal + California tax estimate. All computation is client-side — no data leaves the browser except the per-symbol qualified dividend % which is saved to localStorage.

### CSV import
- **Single drop zone** accepts multiple files at once; format is auto-detected from the header row (Vanguard, Schwab, Schwab RSU)
- Multiple Schwab accounts work — uploads are additive, de-duplicated by `date|category|symbol|amount`
- **Vanguard**: handles two-section CSV (holdings + transactions); extracts `Dividend` and `Interest` rows; sells skipped (no cost basis in export)
- **Schwab simple**: extracts dividends (any action containing "div", e.g. "Qual Div Reinvest") and interest
- **Schwab equity awards**: handles parent/child row structure for RSU sales (Sale row carries date/symbol; RS sub-rows carry gain/holding period); also extracts dividends on held RSU shares

### Tax calculator
- **2026** federal ordinary brackets and standard deduction ($32,200), LTCG/qualified-dividend brackets, and NIIT (3.8% above $250k, unchanged)
- LTCG correctly stacked on top of ordinary taxable income when determining rate
- California: all investment income taxed as ordinary (no preferential LTCG rate); 2025 brackets used (FTB hasn't published 2026 yet), standard deduction $11,412
- Assumes no W-2 income

### UI
- Per-symbol qualified dividend % auto-populated from a built-in lookup table for known funds (VTI, BND, GOOG, etc.), overridable, persisted in localStorage
- Tax summary broken out by income type, federal, and CA
- **Bracket headroom rows** beneath each federal tax line show current rate and how much more income can be realized before the next bracket — especially useful for LTCG where the 0%→15% jump drives sell decisions
- Full transaction table sorted newest first

## Test plan
- [ ] Drop all 4 CSV files at once — Vanguard, two Schwab accounts, Schwab RSU — all load correctly with no double-counting
- [ ] Re-dropping the same file doesn't add duplicates
- [ ] RSU sale transactions appear as LT/ST gains with correct amounts
- [ ] Dividends from Schwab RSU file (GOOG/GOOGL) appear as dividends
- [ ] "Qual Div Reinvest" rows from Schwab brokerage CSV count as dividends
- [ ] Known fund symbols (VTI, BND, etc.) are pre-populated with qualified %
- [ ] Qualified % persists after page reload
- [ ] LTCG bracket headroom correctly reflects stacking (ordinary income consumes the 0% space first)
- [ ] NIIT line only appears when total investment income exceeds $250k

🤖 Generated with [Claude Code](https://claude.ai/claude-code)