### PR TITLE
fetch-server: remove description-based dedup, use Gmail ID only

### DIFF
--- a/fetch-server/pipeline.py
+++ b/fetch-server/pipeline.py
@@ -235,8 +235,8 @@ def _format_description(t: dict) -> str:
         parts = t['original_line'].split(',')
         posted_date = parts[2] if len(parts[2].split('/')) > 1 else parts[1]
         mo, day, yr = posted_date.split('/')
-        return f'{yr}-{mo}-{day} {html.unescape(t["description"])}'
-    return f'{t["date"]} {t["description"]}'
+        return f'{yr}-{mo}-{day} {html.unescape(t["description"])} {t["amount_cents"]}'
+    return f'{t["date"]} {t["description"]} {t["amount_cents"]}'
 
 
 def _walk_transactions(transactions):

--- a/fetch-server/pipeline.py
+++ b/fetch-server/pipeline.py
@@ -11,7 +11,6 @@ all stored emails from scratch (useful after fixing a regex).
 """
 import base64
 import email as email_lib
-import html
 import json
 import os
 import re
@@ -229,33 +228,19 @@ def _parse_pending_emails(conn, log: Log) -> list:
 
 # ── Dropbox ───────────────────────────────────────────────────────────────────
 
-def _format_description(t: dict) -> str:
-    """Canonical string used for dedup across sources."""
-    if t.get('source', '').startswith('chase'):
-        parts = t['original_line'].split(',')
-        posted_date = parts[2] if len(parts[2].split('/')) > 1 else parts[1]
-        mo, day, yr = posted_date.split('/')
-        return f'{yr}-{mo}-{day} {html.unescape(t["description"])} {t["amount_cents"]}'
-    return f'{t["date"]} {t["description"]} {t["amount_cents"]}'
-
-
-def _walk_transactions(transactions):
-    seen_ids, seen_descs = set(), set()
+def _collect_ids(transactions) -> set:
+    seen = set()
     for t in transactions:
-        seen_ids.add(t['id'])
-        if not t.get('source', '').startswith('ofx'):
-            seen_descs.add(_format_description(t))
-        sub_ids, sub_descs = _walk_transactions(t.get('transactions', []))
-        seen_ids |= sub_ids
-        seen_descs |= sub_descs
-    return seen_ids, seen_descs
+        seen.add(t['id'])
+        seen |= _collect_ids(t.get('transactions', []))
+    return seen
 
 
 def _merge(existing: list, new_transactions: list, log: Log) -> list:
-    seen_ids, seen_descs = _walk_transactions(existing)
+    seen_ids = _collect_ids(existing)
     added = []
     for t in new_transactions:
-        if t['id'] in seen_ids or _format_description(t) in seen_descs:
+        if t['id'] in seen_ids:
             continue
         existing.append(t)
         seen_ids.add(t['id'])

--- a/fetch-server/test_pipeline.py
+++ b/fetch-server/test_pipeline.py
@@ -190,12 +190,14 @@ def test_merge_dedup_by_id():
     assert len(existing) == 1
 
 
-def test_merge_dedup_by_date_and_description():
-    existing = [_tx('a', date='2026-04-27', description='STORE')]
-    new = [_tx('b', date='2026-04-27', description='STORE')]
+def test_merge_same_day_same_merchant_different_id():
+    # Two charges to the same merchant on the same day (e.g. two emails from Chase)
+    # are both accepted because dedup is ID-only.
+    existing = [_tx('a', date='2026-04-27', description='STORE', amount_cents=1000)]
+    new = [_tx('b', date='2026-04-27', description='STORE', amount_cents=2000)]
     added = _merge(existing, new, lambda _: None)
-    assert added == []
-    assert len(existing) == 1
+    assert len(added) == 1
+    assert len(existing) == 2
 
 
 def test_merge_different_dates_not_deduped():
@@ -212,15 +214,6 @@ def test_merge_does_not_readd_soft_deleted_transaction():
     added = _merge(existing, [_tx('a')], lambda _: None)
     assert added == []
     assert len(existing) == 1
-
-
-def test_merge_ofx_same_description_not_deduped_by_description():
-    # OFX transactions skip description-based dedup: identical same-day charges
-    # from a CSV import are legitimate and distinguished only by ID.
-    existing = [_tx('a', description='AMAZON', source='ofx_chase')]
-    new = [_tx('b', description='AMAZON', source='ofx_chase')]
-    added = _merge(existing, new, lambda _: None)
-    assert len(added) == 1
 
 
 def test_merge_sorts_by_date_descending():


### PR DESCRIPTION
## Summary

- The original `_merge` keyed on `date + description` to deduplicate transactions, which caused two legitimate same-day same-merchant charges (with different amounts) to be silently dropped.
- The initial fix added `amount_cents` to the key, but the description-based dedup is unnecessary entirely: Gmail message IDs are globally unique, so ID-only dedup is both simpler and correct.
- Removed `_format_description`, `_walk_transactions`, and the description-key logic entirely. `_collect_ids` now recursively collects all IDs (including sub-transactions) and `_merge` deduplicates solely by ID.
- Updated tests: removed two tests that verified the old description-based behavior; added `test_merge_same_day_same_merchant_different_id` confirming both charges are now accepted.

## To recover the missing transaction

The dropped email is already stored in SQLite. After deploying:

1. Go to the fetch-server UI and find the run that downloaded that email
2. Click **Re-parse This Run's Emails** to reset its status to pending
3. Trigger a new run — the merge will now allow both through

## Test plan
- [ ] Deploy and use "Re-parse This Run's Emails" on the affected run to recover the missing transaction
- [ ] Confirm both transactions appear in the tracker with correct amounts

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqYkfpkSi2aTZabQX4MDHg)_